### PR TITLE
fix: discover legacy project configs in ESLint APIs

### DIFF
--- a/npm/utoo-lint/README.md
+++ b/npm/utoo-lint/README.md
@@ -248,6 +248,20 @@ Raw reports include active diagnostics, suppressed diagnostics, fixed outputs,
 and an exit code. The compatibility layer also exports `Linter`, `CLIEngine`,
 `RuleTester`, and `SourceCode` APIs.
 
+`ESLint` and `CLIEngine` also discover classic `.eslintrc.*` files (or
+`eslintConfig` in `package.json`) when no native config applies. Legacy
+`extends`, directory cascades, `root`, `overrides`, and ignore patterns are
+resolved per source filename. Precedence is `baseConfig`, project config,
+then `overrideConfig`; `useEslintrc: false` disables discovery. Native config
+files still take priority. The lower-level `lintFiles`, `lintText`, and native
+CLI keep their native-only discovery behavior.
+
+Legacy configuration resolution uses `@eslint/eslintrc`. If the project has
+ESLint 8 installed, its configuration resolver is used instead to support
+shared configs that patch ESLint's module resolution. Neither path uses ESLint
+to parse or lint source files: rules still run in utoo-lint. Enabled rules that
+utoo-lint does not support remain errors, not silently skipped checks.
+
 The Node wrapper captures up to 64 MiB from each native stdout and stderr
 stream by default. Programmatic `run`, `runCli`, and `runFishlint` calls can set
 `maxBuffer` to another positive byte count. Set `UTOO_LINT_MAX_BUFFER` to apply

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -5,6 +5,7 @@ const { tmpdir } = require("node:os");
 const { dirname, extname, isAbsolute, join, relative, resolve: resolvePath } = require("node:path");
 
 const { platformPackageName, resolveBinary } = require("./lib/binary.cjs");
+const { createLegacyConfigResolver } = require("./lib/legacy-config.cjs");
 const {
   findConfigPath: findConfigPathFromDirectory,
   readConfig
@@ -15,6 +16,8 @@ const version = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf8")
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
 const MAX_AUTOFIX_PASSES = 10;
 const CONFIG_DISCOVERY_CACHE = Symbol("configDiscoveryCache");
+const LEGACY_CONFIG_ENABLED = Symbol("legacyConfigEnabled");
+const LEGACY_CONFIG_RESOLVER = Symbol("legacyConfigResolver");
 const JS_KEYWORDS = new Set([
   "await", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
   "do", "else", "export", "extends", "finally", "for", "function", "if", "import", "in",
@@ -1207,6 +1210,9 @@ function lintFiles(paths, options = {}) {
   if (usesDefaultTargets) {
     lintPaths = filterDefaultConfigLintPaths(lintPaths, options);
   }
+  if (options[LEGACY_CONFIG_ENABLED] && (!options.noConfig || options.legacyConfigFile) && !options.deferDiagnosticConfigFiltering) {
+    lintPaths = expandNativeConfigRunPaths(lintPaths, options).filter((filePath) => !isPathIgnored(filePath, options));
+  }
   if (lintPaths.length === 0) {
     return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, suppressedDiagnostics: [], exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
@@ -1230,6 +1236,10 @@ function lintFiles(paths, options = {}) {
 }
 
 function nativeFlatConfigOptions(options) {
+  if (defersLegacyIgnores(options)) {
+    // A legacy config may cascade from a nested directory even with baseConfig.
+    return undefined;
+  }
   if (options.rules || options.extraArgs?.some((arg) => arg.startsWith("--") && arg !== "--fix" && arg !== "--fix-dry-run")) {
     return undefined;
   }
@@ -1301,7 +1311,7 @@ function nativeSerializableConfig(config) {
 
 function expandNativeConfigRunPaths(paths, options) {
   const cwd = options.cwd ?? process.cwd();
-  const patterns = ignoreDisabled(options) ? [] : ignorePatternsForOptions(options, cwd);
+  const patterns = ignoreDisabled(options) || defersLegacyIgnores(options) ? [] : ignorePatternsForOptions(options, cwd);
   return paths.flatMap((path) => expandLintTarget(path, cwd, patterns) ?? [path]);
 }
 
@@ -1359,7 +1369,7 @@ function finalizeLintReport(report, ignoredDiagnostics, options) {
 }
 
 function nativeConfigRunsForFiles(paths, options) {
-  if (options.noConfig && !options.baseConfig && !options.overrideConfig) {
+  if (options.noConfig && !options.legacyConfigFile && !options.baseConfig && !options.overrideConfig) {
     return undefined;
   }
 
@@ -1370,7 +1380,7 @@ function nativeConfigRunsForFiles(paths, options) {
       ? options.filePath ?? options.filename ?? filePath
       : filePath;
     const fileConfigPath = options.noConfig ? undefined : configPathForFile(options, matchPath);
-    const configured = Boolean(options.baseConfig || options.overrideConfig || fileConfigPath);
+    const configured = Boolean(options.baseConfig || options.overrideConfig || fileConfigPath || legacyConfigForFile(options, matchPath));
     hasConfigSource ||= configured;
     const calculated = configured ? calculatedConfig({ ...options, rules: undefined }, matchPath) : {};
     let rules = calculated.rules;
@@ -1473,7 +1483,9 @@ function isPureRuleSeverity(config) {
 function allDisabledNativeRules(rules) {
   return {
     ...Object.fromEntries(NATIVE_RULE_IDS.map((rule) => [rule, "off"])),
-    ...rules
+    ...Object.fromEntries(Object.entries(rules ?? {}).filter(
+      ([rule, value]) => NATIVE_RULE_IDS.includes(rule) || ruleConfigSeverity(value) > 0
+    ))
   };
 }
 
@@ -1657,6 +1669,7 @@ function withConfigCache(options) {
 
 function eslintConstructorOptions(options) {
   const mapped = {
+    [LEGACY_CONFIG_ENABLED]: true,
     cwd: options.cwd,
     threads: options.threads,
     binary: options.binary,
@@ -1680,13 +1693,12 @@ function eslintConstructorOptions(options) {
   if (typeof options.overrideConfigFile === "string") {
     mapped.config = options.overrideConfigFile;
   }
+  if (mapped.config && /(?:^|[/\\\\])\.eslintrc(?:\.(?:js|cjs|json|yaml|yml))?$/.test(mapped.config)) {
+    mapped.legacyConfigFile = mapped.config;
+    mapped.config = undefined;
+  }
   if (options.overrideConfig) {
     mapped.overrideConfig = Array.isArray(options.overrideConfig) ? options.overrideConfig : { ...options.overrideConfig };
-    if (!Array.isArray(mapped.overrideConfig) && !mapped.overrideConfig.rules && options.baseConfig?.rules) {
-      mapped.overrideConfig.rules = options.baseConfig.rules;
-    }
-  } else if (options.baseConfig?.rules) {
-    mapped.overrideConfig = { rules: options.baseConfig.rules };
   }
   return mapped;
 }
@@ -1818,13 +1830,13 @@ function rulesFromConfig(config, filePath, cwd) {
 }
 
 function rulesFromFileConfig(options, filePath) {
-  if (options.noConfig) {
+  if (options.noConfig && !options.legacyConfigFile) {
     return {};
   }
 
   const configPath = filePath ? configPathForFile(options, filePath) : configPathForOptions(options);
   if (!configPath) {
-    return {};
+    return legacyConfigForFile(options, filePath)?.rules ?? {};
   }
 
   const config = readConfig(configPath, options.cwd, options.configCache);
@@ -1832,17 +1844,38 @@ function rulesFromFileConfig(options, filePath) {
 }
 
 function configDataFromFileConfig(options, filePath) {
-  if (options.noConfig) {
+  if (options.noConfig && !options.legacyConfigFile) {
     return {};
   }
 
   const configPath = filePath ? configPathForFile(options, filePath) : configPathForOptions(options);
   if (!configPath) {
-    return {};
+    return configDataFromConfig(legacyConfigForFile(options, filePath), filePath, options.cwd);
   }
 
   const config = readConfig(configPath, options.cwd, options.configCache);
   return configDataFromConfig(config, filePath, dirname(configPath));
+}
+
+function legacyConfigForFile(options, filePath) {
+  if (!options[LEGACY_CONFIG_ENABLED] || (options.noConfig && !options.legacyConfigFile)) return undefined;
+  if (filePath ? configPathForFile(options, filePath) : configPathForOptions(options)) return undefined;
+  const cwd = resolvePath(options.cwd ?? process.cwd());
+  let resolver = options.configCache?.get(LEGACY_CONFIG_RESOLVER);
+  if (!resolver) {
+    resolver = createLegacyConfigResolver(cwd, {
+      configFile: options.legacyConfigFile,
+      useEslintrc: !options.noConfig,
+      ignorePath: options.ignorePath,
+      ignorePatterns: [
+        ...ignorePatternsFromConfig(options.baseConfig),
+        ...normalizeIgnorePatterns(options.ignorePatterns),
+        ...ignorePatternsFromConfig(options.overrideConfig)
+      ]
+    });
+    options.configCache?.set(LEGACY_CONFIG_RESOLVER, resolver);
+  }
+  return resolver(normalizeESLintFilePath(filePath ?? options.filePath ?? options.filename ?? "__placeholder__.js", cwd));
 }
 
 function lintTargetsForInput(paths, options = {}) {
@@ -1988,6 +2021,7 @@ function normalizeConfigPatterns(patterns) {
 }
 
 function configPathForOptions(options) {
+  if (options.legacyConfigFile) return undefined;
   if (options.config) {
     return resolvePath(options.cwd ?? process.cwd(), options.config);
   }
@@ -1997,6 +2031,7 @@ function configPathForOptions(options) {
 }
 
 function configPathForFile(options, filePath) {
+  if (options.legacyConfigFile) return undefined;
   if (options.noConfig) {
     return undefined;
   }
@@ -4286,7 +4321,7 @@ function isLintableFilePath(filePath) {
 function filteredLintPaths(paths, options = {}) {
   const values = normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths");
   const cwd = options.cwd ?? process.cwd();
-  const patterns = ignoreDisabled(options) ? [] : ignorePatternsForOptions(options, cwd);
+  const patterns = ignoreDisabled(options) || defersLegacyIgnores(options) ? [] : ignorePatternsForOptions(options, cwd);
   if (patterns.length === 0 && options.errorOnUnmatchedPattern !== false && !values.some(hasGlobMagic)) {
     return values;
   }
@@ -4405,7 +4440,7 @@ function ignoredLintPathDiagnostics(paths, options = {}) {
 
   const cwd = options.cwd ?? process.cwd();
   const patterns = ignorePatternsForOptions(options, cwd);
-  if (patterns.length === 0) {
+  if (patterns.length === 0 && !options[LEGACY_CONFIG_ENABLED]) {
     return [];
   }
 
@@ -4422,7 +4457,7 @@ function ignoredLintPathDiagnostics(paths, options = {}) {
       continue;
     }
 
-    if (pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns)) {
+    if (isPathIgnored(filePath, options)) {
       diagnostics.push(ignoredFileDiagnostic(filePath));
     }
   }
@@ -4494,9 +4529,17 @@ function isPathIgnored(filePath, options = {}) {
   }
 
   const cwd = options.cwd ?? process.cwd();
+  const legacyConfig = legacyConfigForFile(options, filePath);
+  if (legacyConfig) {
+    return Boolean(legacyConfig.isIgnored?.(normalizeESLintFilePath(filePath, cwd)));
+  }
   const normalized = normalizeIgnoredPath(filePath, cwd);
   const patterns = ignorePatternsForOptions(options, cwd, filePath);
   return pathIgnoredByPatterns(normalized, patterns);
+}
+
+function defersLegacyIgnores(options) {
+  return options[LEGACY_CONFIG_ENABLED] && (options.legacyConfigFile || (!options.noConfig && !configPathForOptions(options)));
 }
 
 function ignoreDisabled(options = {}) {

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -582,6 +582,9 @@ class UtooLint {
 
   async findConfigFile(filePath) {
     const options = withConfigCache(eslintConstructorOptions(this.options));
+    if (options.legacyConfigFile) {
+      return resolvePath(options.cwd ?? process.cwd(), options.legacyConfigFile);
+    }
     if (options.noConfig) {
       return undefined;
     }
@@ -1675,7 +1678,8 @@ function eslintConstructorOptions(options) {
     binary: options.binary,
     env: options.env,
     extraArgs: options.extraArgs,
-    config: options.config ?? options.configFile,
+    config: options.config,
+    legacyConfigFile: options.config == null ? options.configFile : undefined,
     ignorePath: options.ignorePath,
     ignorePatterns: options.ignorePatterns,
     noIgnore: options.noIgnore ?? options.ignore === false,
@@ -1692,6 +1696,7 @@ function eslintConstructorOptions(options) {
   }
   if (typeof options.overrideConfigFile === "string") {
     mapped.config = options.overrideConfigFile;
+    mapped.legacyConfigFile = undefined;
   }
   if (mapped.config && /(?:^|[/\\\\])\.eslintrc(?:\.(?:js|cjs|json|yaml|yml))?$/.test(mapped.config)) {
     mapped.legacyConfigFile = mapped.config;

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -6,6 +6,7 @@ import { dirname, extname, isAbsolute, join, relative, resolve as resolvePath } 
 import { fileURLToPath } from "node:url";
 
 import { resolveBinary } from "./lib/binary.js";
+import { createLegacyConfigResolver } from "./lib/legacy-config.cjs";
 import {
   findConfigPath as findConfigPathFromDirectory,
   readConfig
@@ -18,6 +19,8 @@ export const version = JSON.parse(readFileSync(new URL("./package.json", import.
 const LINTABLE_EXTENSIONS = new Set([".js", ".jsx", ".ts", ".tsx", ".mjs", ".cjs", ".mts", ".cts"]);
 const MAX_AUTOFIX_PASSES = 10;
 const CONFIG_DISCOVERY_CACHE = Symbol("configDiscoveryCache");
+const LEGACY_CONFIG_ENABLED = Symbol("legacyConfigEnabled");
+const LEGACY_CONFIG_RESOLVER = Symbol("legacyConfigResolver");
 const JS_KEYWORDS = new Set([
   "await", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete",
   "do", "else", "export", "extends", "finally", "for", "function", "if", "import", "in",
@@ -3106,6 +3109,9 @@ export function lintFiles(paths, options = {}) {
   if (usesDefaultTargets) {
     lintPaths = filterDefaultConfigLintPaths(lintPaths, options);
   }
+  if (options[LEGACY_CONFIG_ENABLED] && (!options.noConfig || options.legacyConfigFile) && !options.deferDiagnosticConfigFiltering) {
+    lintPaths = expandNativeConfigRunPaths(lintPaths, options).filter((filePath) => !isPathIgnored(filePath, options));
+  }
   if (lintPaths.length === 0) {
     return { files: 0, filePaths: [], diagnostics: ignoredDiagnostics, suppressedDiagnostics: [], exitCode: exitCodeForDiagnostics(ignoredDiagnostics) };
   }
@@ -3129,6 +3135,10 @@ export function lintFiles(paths, options = {}) {
 }
 
 function nativeFlatConfigOptions(options) {
+  if (defersLegacyIgnores(options)) {
+    // A legacy config may cascade from a nested directory even with baseConfig.
+    return undefined;
+  }
   if (options.rules || options.extraArgs?.some((arg) => arg.startsWith("--") && arg !== "--fix" && arg !== "--fix-dry-run")) {
     return undefined;
   }
@@ -3200,7 +3210,7 @@ function nativeSerializableConfig(config) {
 
 function expandNativeConfigRunPaths(paths, options) {
   const cwd = options.cwd ?? process.cwd();
-  const patterns = ignoreDisabled(options) ? [] : ignorePatternsForOptions(options, cwd);
+  const patterns = ignoreDisabled(options) || defersLegacyIgnores(options) ? [] : ignorePatternsForOptions(options, cwd);
   return paths.flatMap((path) => expandLintTarget(path, cwd, patterns) ?? [path]);
 }
 
@@ -3258,7 +3268,7 @@ function finalizeLintReport(report, ignoredDiagnostics, options) {
 }
 
 function nativeConfigRunsForFiles(paths, options) {
-  if (options.noConfig && !options.baseConfig && !options.overrideConfig) {
+  if (options.noConfig && !options.legacyConfigFile && !options.baseConfig && !options.overrideConfig) {
     return undefined;
   }
 
@@ -3269,7 +3279,7 @@ function nativeConfigRunsForFiles(paths, options) {
       ? options.filePath ?? options.filename ?? filePath
       : filePath;
     const fileConfigPath = options.noConfig ? undefined : configPathForFile(options, matchPath);
-    const configured = Boolean(options.baseConfig || options.overrideConfig || fileConfigPath);
+    const configured = Boolean(options.baseConfig || options.overrideConfig || fileConfigPath || legacyConfigForFile(options, matchPath));
     hasConfigSource ||= configured;
     const calculated = configured ? calculatedConfig({ ...options, rules: undefined }, matchPath) : {};
     let rules = calculated.rules;
@@ -3372,7 +3382,9 @@ function isPureRuleSeverity(config) {
 function allDisabledNativeRules(rules) {
   return {
     ...Object.fromEntries(NATIVE_RULE_IDS.map((rule) => [rule, "off"])),
-    ...rules
+    ...Object.fromEntries(Object.entries(rules ?? {}).filter(
+      ([rule, value]) => NATIVE_RULE_IDS.includes(rule) || ruleConfigSeverity(value) > 0
+    ))
   };
 }
 
@@ -3556,6 +3568,7 @@ function withConfigCache(options) {
 
 function eslintConstructorOptions(options) {
   const mapped = {
+    [LEGACY_CONFIG_ENABLED]: true,
     cwd: options.cwd,
     threads: options.threads,
     binary: options.binary,
@@ -3579,13 +3592,12 @@ function eslintConstructorOptions(options) {
   if (typeof options.overrideConfigFile === "string") {
     mapped.config = options.overrideConfigFile;
   }
+  if (mapped.config && /(?:^|[/\\\\])\.eslintrc(?:\.(?:js|cjs|json|yaml|yml))?$/.test(mapped.config)) {
+    mapped.legacyConfigFile = mapped.config;
+    mapped.config = undefined;
+  }
   if (options.overrideConfig) {
     mapped.overrideConfig = Array.isArray(options.overrideConfig) ? options.overrideConfig : { ...options.overrideConfig };
-    if (!Array.isArray(mapped.overrideConfig) && !mapped.overrideConfig.rules && options.baseConfig?.rules) {
-      mapped.overrideConfig.rules = options.baseConfig.rules;
-    }
-  } else if (options.baseConfig?.rules) {
-    mapped.overrideConfig = { rules: options.baseConfig.rules };
   }
   return mapped;
 }
@@ -3717,13 +3729,13 @@ function rulesFromConfig(config, filePath, cwd) {
 }
 
 function rulesFromFileConfig(options, filePath) {
-  if (options.noConfig) {
+  if (options.noConfig && !options.legacyConfigFile) {
     return {};
   }
 
   const configPath = filePath ? configPathForFile(options, filePath) : configPathForOptions(options);
   if (!configPath) {
-    return {};
+    return legacyConfigForFile(options, filePath)?.rules ?? {};
   }
 
   const config = readConfig(configPath, options.cwd, options.configCache);
@@ -3731,17 +3743,38 @@ function rulesFromFileConfig(options, filePath) {
 }
 
 function configDataFromFileConfig(options, filePath) {
-  if (options.noConfig) {
+  if (options.noConfig && !options.legacyConfigFile) {
     return {};
   }
 
   const configPath = filePath ? configPathForFile(options, filePath) : configPathForOptions(options);
   if (!configPath) {
-    return {};
+    return configDataFromConfig(legacyConfigForFile(options, filePath), filePath, options.cwd);
   }
 
   const config = readConfig(configPath, options.cwd, options.configCache);
   return configDataFromConfig(config, filePath, dirname(configPath));
+}
+
+function legacyConfigForFile(options, filePath) {
+  if (!options[LEGACY_CONFIG_ENABLED] || (options.noConfig && !options.legacyConfigFile)) return undefined;
+  if (filePath ? configPathForFile(options, filePath) : configPathForOptions(options)) return undefined;
+  const cwd = resolvePath(options.cwd ?? process.cwd());
+  let resolver = options.configCache?.get(LEGACY_CONFIG_RESOLVER);
+  if (!resolver) {
+    resolver = createLegacyConfigResolver(cwd, {
+      configFile: options.legacyConfigFile,
+      useEslintrc: !options.noConfig,
+      ignorePath: options.ignorePath,
+      ignorePatterns: [
+        ...ignorePatternsFromConfig(options.baseConfig),
+        ...normalizeIgnorePatterns(options.ignorePatterns),
+        ...ignorePatternsFromConfig(options.overrideConfig)
+      ]
+    });
+    options.configCache?.set(LEGACY_CONFIG_RESOLVER, resolver);
+  }
+  return resolver(normalizeESLintFilePath(filePath ?? options.filePath ?? options.filename ?? "__placeholder__.js", cwd));
 }
 
 function lintTargetsForInput(paths, options = {}) {
@@ -3887,6 +3920,7 @@ function normalizeConfigPatterns(patterns) {
 }
 
 function configPathForOptions(options) {
+  if (options.legacyConfigFile) return undefined;
   if (options.config) {
     return resolvePath(options.cwd ?? process.cwd(), options.config);
   }
@@ -3896,6 +3930,7 @@ function configPathForOptions(options) {
 }
 
 function configPathForFile(options, filePath) {
+  if (options.legacyConfigFile) return undefined;
   if (options.noConfig) {
     return undefined;
   }
@@ -4289,7 +4324,7 @@ function isLintableFilePath(filePath) {
 function filteredLintPaths(paths, options = {}) {
   const values = normalizeStringArray(Array.isArray(paths) ? paths : [paths], "paths");
   const cwd = options.cwd ?? process.cwd();
-  const patterns = ignoreDisabled(options) ? [] : ignorePatternsForOptions(options, cwd);
+  const patterns = ignoreDisabled(options) || defersLegacyIgnores(options) ? [] : ignorePatternsForOptions(options, cwd);
   if (patterns.length === 0 && options.errorOnUnmatchedPattern !== false && !values.some(hasGlobMagic)) {
     return values;
   }
@@ -4408,7 +4443,7 @@ function ignoredLintPathDiagnostics(paths, options = {}) {
 
   const cwd = options.cwd ?? process.cwd();
   const patterns = ignorePatternsForOptions(options, cwd);
-  if (patterns.length === 0) {
+  if (patterns.length === 0 && !options[LEGACY_CONFIG_ENABLED]) {
     return [];
   }
 
@@ -4425,7 +4460,7 @@ function ignoredLintPathDiagnostics(paths, options = {}) {
       continue;
     }
 
-    if (pathIgnoredByPatterns(normalizeIgnoredPath(target, cwd), patterns)) {
+    if (isPathIgnored(filePath, options)) {
       diagnostics.push(ignoredFileDiagnostic(filePath));
     }
   }
@@ -4497,9 +4532,17 @@ function isPathIgnored(filePath, options = {}) {
   }
 
   const cwd = options.cwd ?? process.cwd();
+  const legacyConfig = legacyConfigForFile(options, filePath);
+  if (legacyConfig) {
+    return Boolean(legacyConfig.isIgnored?.(normalizeESLintFilePath(filePath, cwd)));
+  }
   const normalized = normalizeIgnoredPath(filePath, cwd);
   const patterns = ignorePatternsForOptions(options, cwd, filePath);
   return pathIgnoredByPatterns(normalized, patterns);
+}
+
+function defersLegacyIgnores(options) {
+  return options[LEGACY_CONFIG_ENABLED] && (options.legacyConfigFile || (!options.noConfig && !configPathForOptions(options)));
 }
 
 function ignoreDisabled(options = {}) {

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -585,6 +585,9 @@ export class UtooLint {
 
   async findConfigFile(filePath) {
     const options = withConfigCache(eslintConstructorOptions(this.options));
+    if (options.legacyConfigFile) {
+      return resolvePath(options.cwd ?? process.cwd(), options.legacyConfigFile);
+    }
     if (options.noConfig) {
       return undefined;
     }
@@ -3574,7 +3577,8 @@ function eslintConstructorOptions(options) {
     binary: options.binary,
     env: options.env,
     extraArgs: options.extraArgs,
-    config: options.config ?? options.configFile,
+    config: options.config,
+    legacyConfigFile: options.config == null ? options.configFile : undefined,
     ignorePath: options.ignorePath,
     ignorePatterns: options.ignorePatterns,
     noIgnore: options.noIgnore ?? options.ignore === false,
@@ -3591,6 +3595,7 @@ function eslintConstructorOptions(options) {
   }
   if (typeof options.overrideConfigFile === "string") {
     mapped.config = options.overrideConfigFile;
+    mapped.legacyConfigFile = undefined;
   }
   if (mapped.config && /(?:^|[/\\\\])\.eslintrc(?:\.(?:js|cjs|json|yaml|yml))?$/.test(mapped.config)) {
     mapped.legacyConfigFile = mapped.config;

--- a/npm/utoo-lint/lib/legacy-config.cjs
+++ b/npm/utoo-lint/lib/legacy-config.cjs
@@ -1,0 +1,76 @@
+const { createRequire } = require("node:module");
+const { dirname, join, resolve } = require("node:path");
+
+// The same reviewed aliases used by the ESLint config migrator.
+const RULE_ALIASES = new Map([
+  ["no-native-reassign", "no-global-assign"],
+  ["@typescript-eslint/no-invalid-this", "no-invalid-this"]
+]);
+
+// Resolve configuration only. Parsing, rule execution, and fixes stay native.
+function createLegacyConfigResolver(cwd, { ignorePath, ignorePatterns, configFile, useEslintrc = true } = {}) {
+  const resolvedIgnorePath = ignorePath ? resolve(cwd, ignorePath) : undefined;
+  const resolvedConfigFile = configFile ? resolve(cwd, configFile) : undefined;
+  const projectRequire = createRequire(join(cwd, "package.json"));
+  let eslintPackage;
+  try {
+    eslintPackage = projectRequire.resolve("eslint/package.json");
+  } catch (error) {
+    if (error.code !== "MODULE_NOT_FOUND") throw error;
+  }
+
+  let load;
+  if (eslintPackage) {
+    const manifest = projectRequire(eslintPackage);
+    // Some shared configs patch ESLint's module-resolution internals. Use their
+    // own ESLint 8 config resolver when installed, and never recurse into an
+    // eslint package alias that points back to @utoo/lint.
+    const major = Number(manifest.version.split(".")[0]);
+    if (manifest.name === "eslint" && major === 8) {
+      const { CLIEngine } = projectRequire(join(dirname(eslintPackage), "lib/cli-engine/cli-engine.js"));
+      const engine = new CLIEngine({ cwd, ignorePath: resolvedIgnorePath, ignorePattern: ignorePatterns, configFile: resolvedConfigFile, useEslintrc });
+      load = (filePath) => {
+        try {
+          return { ...engine.getConfigForFile(filePath), isIgnored: (path) => engine.isPathIgnored(path) };
+        } catch (error) {
+          if (error.messageTemplate === "no-config-found") return undefined;
+          throw error;
+        }
+      };
+    }
+  }
+
+  if (!load) {
+    const { Legacy } = require("@eslint/eslintrc");
+    const eslintJs = require("@eslint/js");
+    const factory = new Legacy.CascadingConfigArrayFactory({
+      cwd,
+      specificConfigPath: resolvedConfigFile,
+      useEslintrc,
+      ignorePath: resolvedIgnorePath,
+      cliConfig: ignorePatterns?.length ? { ignorePatterns } : undefined,
+      getEslintRecommendedConfig: () => eslintJs.configs.recommended,
+      getEslintAllConfig: () => eslintJs.configs.all
+    });
+    load = (filePath) => {
+      const configs = factory.getConfigArrayForFile(filePath, { ignoreNotFoundError: true });
+      if (!configs.some((entry) => entry.type === "config" && entry.filePath)) return undefined;
+      const config = configs.extractConfig(filePath);
+      return { ...config.toCompatibleObjectAsConfigFileContent(), isIgnored: config.ignores };
+    };
+  }
+
+  const configs = new Map();
+  return (filePath) => {
+    if (!configs.has(filePath)) {
+      const config = load(filePath);
+      if (config) {
+        config.rules = Object.fromEntries(Object.entries(config.rules).map(([rule, value]) => [RULE_ALIASES.get(rule) ?? rule, value]));
+      }
+      configs.set(filePath, config);
+    }
+    return configs.get(filePath);
+  };
+}
+
+module.exports = { createLegacyConfigResolver };

--- a/npm/utoo-lint/test/eslint-legacy-config.test.mjs
+++ b/npm/utoo-lint/test/eslint-legacy-config.test.mjs
@@ -9,7 +9,7 @@ import test from "node:test";
 import { CLIEngine, ESLint, lintText } from "../index.js";
 
 const require = createRequire(import.meta.url);
-const { CLIEngine: CommonJSCLIEngine } = require("../index.cjs");
+const { CLIEngine: CommonJSCLIEngine, ESLint: CommonJSESLint } = require("../index.cjs");
 
 process.env.UTOO_LINT_BIN ??= fileURLToPath(new URL(
   `../../../zig-out/bin/utoo-lint${process.platform === "win32" ? ".exe" : ""}`,
@@ -163,5 +163,64 @@ test("explicit eslintrc files resolve extends even with automatic discovery disa
     assert.deepEqual(engine.getConfigForFile(file).rules["no-alert"], [2]);
     assert.equal(engine.getConfigForFile(file).rules["no-debugger"], undefined);
     assert.equal(engine.executeOnFiles([file]).errorCount, 1);
+  }
+});
+
+test("CLIEngine configFile loads arbitrary legacy filenames with or without discovery", (t) => {
+  const cwd = project(t);
+  write(join(cwd, ".eslintrc.json"), JSON.stringify({ root: true, rules: { "no-debugger": 2 } }));
+  write(join(cwd, "configs", "preset.cjs"), 'module.exports = { rules: { "no-alert": 2 } };');
+  write(join(cwd, "configs", "lint.cjs"), 'module.exports = { extends: "./preset.cjs" };');
+  const file = write(join(cwd, "index.js"), "alert('message'); debugger;");
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    for (const useEslintrc of [false, true]) {
+      const engine = new Engine({ cwd, configFile: "configs/lint.cjs", useEslintrc });
+      assert.deepEqual(engine.getConfigForFile(file).rules["no-alert"], [2]);
+      assert.equal(engine.executeOnFiles([file]).errorCount, useEslintrc ? 2 : 1);
+      assert.equal(engine.executeOnText("alert('message'); debugger;", file).errorCount, useEslintrc ? 2 : 1);
+    }
+  }
+});
+
+test("findConfigFile returns the explicit legacy path even with discovery disabled", async (t) => {
+  const cwd = project(t);
+  write(join(cwd, "utlint.config.json"), JSON.stringify({ rules: { "no-debugger": "off" } }));
+  const file = write(join(cwd, "src", "index.js"), "debugger;");
+  for (const filename of ["configs/lint.cjs", "configs/.eslintrc.cjs"]) {
+    write(join(cwd, filename), 'module.exports = { rules: { "no-debugger": 2 } };');
+  }
+  for (const Engine of [ESLint, CommonJSESLint]) {
+    for (const explicit of [
+      { configFile: "configs/lint.cjs" },
+      { overrideConfigFile: "configs/.eslintrc.cjs" },
+    ]) {
+      for (const useEslintrc of [false, true]) {
+        const engine = new Engine({ cwd, ...explicit, useEslintrc });
+        const expected = join(cwd, explicit.configFile ?? explicit.overrideConfigFile);
+        assert.equal(await engine.findConfigFile(), expected);
+        assert.equal(await engine.findConfigFile(file), expected);
+        assert.deepEqual((await engine.calculateConfigForFile(file)).rules["no-debugger"], [2]);
+        assert.equal((await engine.lintText("debugger;", { filePath: file }))[0].errorCount, 1);
+      }
+    }
+  }
+});
+
+test("explicit native config options keep precedence over legacy configFile", (t) => {
+  const cwd = project(t);
+  write(join(cwd, "legacy.cjs"), 'throw new Error("superseded legacy config must not load");');
+  write(join(cwd, "native.json"), JSON.stringify({ rules: { "no-debugger": "error" } }));
+  write(join(cwd, "override.json"), JSON.stringify({ rules: { "no-alert": "error" } }));
+  const file = write(join(cwd, "index.js"), "alert('message'); debugger;");
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    for (const options of [
+      { config: "native.json", expected: "no-debugger" },
+      { overrideConfigFile: "override.json", expected: "no-alert" },
+      { config: "native.json", overrideConfigFile: "override.json", expected: "no-alert" },
+    ]) {
+      const { expected, ...configOptions } = options;
+      const engine = new Engine({ cwd, configFile: "legacy.cjs", ...configOptions });
+      assert.deepEqual(engine.executeOnFiles([file]).results[0].messages.map((message) => message.ruleId), [expected]);
+    }
   }
 });

--- a/npm/utoo-lint/test/eslint-legacy-config.test.mjs
+++ b/npm/utoo-lint/test/eslint-legacy-config.test.mjs
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { CLIEngine, ESLint, lintText } from "../index.js";
+
+const require = createRequire(import.meta.url);
+const { CLIEngine: CommonJSCLIEngine } = require("../index.cjs");
+
+process.env.UTOO_LINT_BIN ??= fileURLToPath(new URL(
+  `../../../zig-out/bin/utoo-lint${process.platform === "win32" ? ".exe" : ""}`,
+  import.meta.url
+));
+
+function project(t) {
+  const cwd = mkdtempSync(join(tmpdir(), "utoo-lint-legacy-config-"));
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  return cwd;
+}
+
+function write(path, source) {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, source);
+  return path;
+}
+
+test("ESLint compatibility APIs load project eslintrc rules above baseConfig", (t) => {
+  const cwd = project(t);
+  write(join(cwd, ".eslintrc.cjs"), 'module.exports = { root: true, rules: { "no-alert": 2, "no-debugger": 0 } };');
+  const file = write(join(cwd, "src", "index.js"), "alert('message'); debugger;\n");
+
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    const engine = new Engine({ cwd, baseConfig: { rules: { "no-debugger": 2 } } });
+    const config = engine.getConfigForFile(file);
+    assert.deepEqual(config.rules["no-alert"], [2]);
+    assert.deepEqual(config.rules["no-debugger"], [0]);
+    const report = engine.executeOnFiles([file]);
+    assert.equal(report.errorCount, 1);
+    assert.deepEqual(report.results.flatMap((r) => r.messages.map((m) => m.ruleId)), ["no-alert"]);
+  }
+});
+
+test("legacy extends and overrides apply to the requested filename, including editor text", async (t) => {
+  const cwd = project(t);
+  write(join(cwd, "preset.cjs"), 'module.exports = { rules: { "no-alert": 2, "no-debugger": 2 } };');
+  write(join(cwd, ".eslintrc.cjs"), `module.exports = {
+    root: true, extends: "./preset.cjs",
+    overrides: [{ files: ["*.test.js"], rules: { "no-alert": 0 } }]
+  };`);
+  const regular = write(join(cwd, "src", "index.js"), "alert('message'); debugger;");
+  const testFile = write(join(cwd, "src", "index.test.js"), "alert('message'); debugger;");
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    const engine = new Engine({ cwd, baseConfig: [{ rules: { "no-alert": 1 } }] });
+    assert.equal(engine.executeOnFiles([regular]).errorCount, 2);
+    assert.equal(engine.executeOnFiles([testFile]).errorCount, 1);
+    assert.equal(engine.executeOnText("alert('message'); debugger;", testFile).errorCount, 1);
+    const overridden = new Engine({ cwd, overrideConfig: { rules: { "no-debugger": 0 } } });
+    assert.equal(overridden.executeOnFiles([testFile]).errorCount, 0);
+  }
+  const eslint = new ESLint({ cwd });
+  assert.deepEqual((await eslint.calculateConfigForFile(testFile)).rules["no-alert"], [0]);
+  assert.equal((await eslint.lintText("alert('message'); debugger;", { filePath: testFile }))[0].errorCount, 1);
+});
+
+test("legacy cascades respect nested configs, root boundaries, and ignored files", (t) => {
+  const parent = project(t);
+  write(join(parent, ".eslintrc.json"), JSON.stringify({ rules: { "no-alert": 2 } }));
+  const cwd = join(parent, "app");
+  write(join(cwd, ".eslintrc.json"), JSON.stringify({ root: true, ignorePatterns: ["generated/"], rules: { "no-debugger": 2 } }));
+  write(join(cwd, "src", ".eslintrc.json"), JSON.stringify({ rules: { "no-debugger": 0 } }));
+  const rootFile = write(join(cwd, "index.js"), "alert('message'); debugger;");
+  const nestedFile = write(join(cwd, "src", "index.js"), "alert('message'); debugger;");
+  const ignoredFile = write(join(cwd, "generated", "index.js"), "debugger;");
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    const engine = new Engine({ cwd });
+    assert.equal(engine.executeOnFiles([rootFile, nestedFile]).errorCount, 1);
+    assert.equal(engine.isPathIgnored(ignoredFile), true);
+    assert.equal(engine.executeOnFiles(["."]).errorCount, 1);
+    assert.equal(engine.executeOnText("debugger;", ignoredFile).errorCount, 0);
+    assert.equal(new Engine({ cwd, ignore: false }).executeOnFiles([ignoredFile]).errorCount, 1);
+  }
+});
+
+test("legacy discovery observes edits and opt-outs without changing the native APIs", (t) => {
+  const cwd = project(t);
+  const configFile = write(join(cwd, ".eslintrc.cjs"), 'module.exports = { root: true, rules: { "no-debugger": 2 } };');
+  const file = write(join(cwd, "index.js"), "debugger;");
+  const engine = new CLIEngine({ cwd });
+  assert.equal(engine.executeOnFiles([file]).errorCount, 1);
+  write(configFile, 'module.exports = { root: true, rules: { "no-debugger": 0 } };');
+  assert.equal(engine.executeOnFiles([file]).errorCount, 0);
+  assert.deepEqual(engine.getConfigForFile(file).rules["no-debugger"], [0]);
+
+  write(configFile, 'throw new Error("legacy config must not load");');
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    const disabled = new Engine({ cwd, useEslintrc: false, baseConfig: { rules: { "no-debugger": 2 } } });
+    assert.equal(disabled.executeOnFiles([file]).errorCount, 1);
+  }
+  assert.equal(lintText("debugger;", { cwd, filePath: file, overrideConfig: { rules: { "no-debugger": 2 } } }).diagnostics.length, 1);
+  write(join(cwd, "utlint.config.json"), JSON.stringify({ rules: { "no-debugger": "off" } }));
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    assert.equal(new Engine({ cwd }).executeOnFiles([file]).errorCount, 0);
+  }
+});
+
+test("legacy rule aliases reach their native equivalents without dropping unsupported enabled rules", (t) => {
+  const cwd = project(t);
+  const configFile = write(join(cwd, ".eslintrc.json"), JSON.stringify({
+    root: true, rules: { "no-native-reassign": 2 }
+  }));
+  const file = write(join(cwd, "index.js"), "Object = 1;");
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    const report = new Engine({ cwd }).executeOnFiles([file]);
+    assert.equal(report.errorCount, 1);
+    assert.equal(report.results[0].messages[0].ruleId, "no-global-assign");
+  }
+  write(configFile, JSON.stringify({ root: true, rules: { "unsupported-rule-for-test": 2 } }));
+  assert.throws(() => new CLIEngine({ cwd }).executeOnFiles([file]), /unknown rule|unsupported-rule-for-test/);
+  write(configFile, JSON.stringify({ root: true, rules: { "unsupported-rule-for-test": 0, "no-global-assign": [2, { exceptions: ["Object"] }] } }));
+  assert.equal(new CLIEngine({ cwd }).executeOnFiles([file]).errorCount, 0);
+});
+
+test("package.json eslintConfig works when eslint is aliased to utoo-lint", (t) => {
+  const cwd = project(t);
+  write(join(cwd, "package.json"), JSON.stringify({ eslintConfig: { root: true, rules: { "no-debugger": 2 } } }));
+  mkdirSync(join(cwd, "node_modules"));
+  symlinkSync(fileURLToPath(new URL("..", import.meta.url)), join(cwd, "node_modules", "eslint"), "junction");
+  const file = write(join(cwd, "index.js"), "debugger;");
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    assert.equal(new Engine({ cwd }).executeOnFiles([file]).errorCount, 1);
+  }
+});
+
+test("CLI ignore options override legacy ignores and replace the default ignore file", (t) => {
+  const cwd = project(t);
+  write(join(cwd, ".eslintrc.json"), JSON.stringify({ root: true, ignorePatterns: ["generated/*"], rules: { "no-debugger": 2 } }));
+  write(join(cwd, ".eslintignore"), "default.js\n");
+  write(join(cwd, "custom.ignore"), "custom.js\n");
+  const file = write(join(cwd, "generated", "keep.js"), "debugger;");
+  const defaultFile = write(join(cwd, "default.js"), "debugger;");
+  const customFile = write(join(cwd, "custom.js"), "debugger;");
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    const engine = new Engine({ cwd, ignorePath: "custom.ignore", ignorePatterns: ["!generated/keep.js"] });
+    assert.equal(engine.isPathIgnored(file), false);
+    assert.equal(engine.isPathIgnored(defaultFile), false);
+    assert.equal(engine.isPathIgnored(customFile), true);
+    assert.equal(engine.executeOnFiles(["."]).errorCount, 2);
+  }
+});
+
+test("explicit eslintrc files resolve extends even with automatic discovery disabled", (t) => {
+  const cwd = project(t);
+  write(join(cwd, ".eslintrc.json"), JSON.stringify({ root: true, rules: { "no-debugger": 2 } }));
+  write(join(cwd, "configs", "preset.cjs"), 'module.exports = { rules: { "no-alert": 2 } };');
+  write(join(cwd, "configs", ".eslintrc.cjs"), 'module.exports = { extends: "./preset.cjs" };');
+  const file = write(join(cwd, "index.js"), "alert('message'); debugger;");
+  for (const Engine of [CLIEngine, CommonJSCLIEngine]) {
+    const engine = new Engine({ cwd, configFile: "configs/.eslintrc.cjs", useEslintrc: false });
+    assert.deepEqual(engine.getConfigForFile(file).rules["no-alert"], [2]);
+    assert.equal(engine.getConfigForFile(file).rules["no-debugger"], undefined);
+    assert.equal(engine.executeOnFiles([file]).errorCount, 1);
+  }
+});


### PR DESCRIPTION
## Summary

- Discover classic project `.eslintrc.*` / `package.json#eslintConfig` through the ESLint compatibility APIs, without changing native CLI or low-level API discovery.
- Preserve `extends`, `root`, nested configs, per-file overrides, ignore rules, explicit eslintrc files, and editor filenames.
- Apply configuration in base → project → override order instead of duplicating base rules into the highest-priority override.
- Reuse one resolver per public invocation; later invocations observe edited configs.
- Translate the two reviewed legacy aliases used by Umi. Unknown enabled rules still fail; disabled unknown rules are not sent to the native engine.

## Why

Umi's former integration passed a built-in preset as `baseConfig`. The compatibility layer discovered only native config files, silently losing project `.eslintrc` customizations. A real project configured `@typescript-eslint/no-use-before-define` options and `@typescript-eslint/no-explicit-any`, but neither customization reached linting.

The legacy resolver uses the existing `@eslint/eslintrc` dependency. If the project has ESLint 8, it uses that installation's configuration resolver to support shared configs that patch ESLint module resolution (including Umi's Rushstack setup). This does **not** use ESLint for parsing or rule execution.

## Local validation

- Combined local verification of #1199, #1200, and #1201: the unchanged Bigfish project's `tnpm run lint` reports 2 errors instead of 8. Only the two genuine missing-JSX-key diagnostics remain (exit code 1).
- With the real project config, `export const debugValue: any = 1;` produces one error at a regular source filename and zero at its configured DebugView exemption. The combined targeted API suite passes all 9 tests.

- Regression test observed failing before implementation: project rule missing from `getConfigForFile`.
- Eight targeted integration tests cover ESM/CommonJS and both synchronous/editor-style APIs, cascades/overrides/ignores, config changes, opt-outs, native priority, package aliases, explicit files, and unsupported rules.
- Full npm package suite: 165 tests plus TypeScript checks passed on Node 24.
- Targeted tests also pass on Node 20.
- Real Bigfish project configuration now yields the configured rule severity and `{ functions: false, classes: true }` options.

Umi's reverted integration stays reverted. Business-project verification is local only. The separately added `no-explicit-any` native rule in #1201 is needed for projects that enable that rule; loading a config alone does not make unsupported rules available. Parameter-property false positives are addressed independently in #1199.
