### PR TITLE
feat: support TypeScript no-explicit-any

### DIFF
--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -399,6 +399,7 @@ instead of being rewritten.
 | [`@typescript-eslint/no-duplicate-enum-values`](https://typescript-eslint.io/rules/no-duplicate-enum-values/) | Implemented |
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | Implemented with autofix |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | Implemented |
+| [`@typescript-eslint/no-explicit-any`](https://typescript-eslint.io/rules/no-explicit-any/) | Opt-in; supports `ignoreRestArgs`, `fixToUnknown`, and editor suggestions for `unknown` and `never` |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | Supports `ignoreParameters` and `ignoreProperties` configuration |
 | [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | Supports `allowAsThisParameter` and boolean/string-list `allowInGenericTypeArguments` configuration |
 | [`@typescript-eslint/no-loop-func`](https://typescript-eslint.io/rules/no-loop-func/) | Implemented for TypeScript loop captures with core `no-loop-func` fallback when disabled |

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -398,6 +398,7 @@
 | [`@typescript-eslint/no-duplicate-enum-values`](https://typescript-eslint.io/rules/no-duplicate-enum-values/) | 已实现 |
 | [`@typescript-eslint/no-extra-semi`](https://typescript-eslint.io/rules/no-extra-semi/) | 已实现并支持自动修复 |
 | [`@typescript-eslint/no-extra-non-null-assertion`](https://typescript-eslint.io/rules/no-extra-non-null-assertion/) | 已实现 |
+| [`@typescript-eslint/no-explicit-any`](https://typescript-eslint.io/rules/no-explicit-any/) | 按配置启用；支持 `ignoreRestArgs`、`fixToUnknown` 及替换为 `unknown` 或 `never` 的编辑器建议 |
 | [`@typescript-eslint/no-inferrable-types`](https://typescript-eslint.io/rules/no-inferrable-types/) | 支持 `ignoreParameters` 和 `ignoreProperties` 配置 |
 | [`@typescript-eslint/no-invalid-void-type`](https://typescript-eslint.io/rules/no-invalid-void-type/) | 支持 `allowAsThisParameter`，以及布尔值/字符串列表形式的 `allowInGenericTypeArguments` 配置 |
 | [`@typescript-eslint/no-loop-func`](https://typescript-eslint.io/rules/no-loop-func/) | 已实现 TypeScript 循环捕获检查；禁用时回退到核心 `no-loop-func` |

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -415,6 +415,7 @@ const BUILTIN_RULE_IDS = [
   "@typescript-eslint/no-duplicate-enum-values",
   "@typescript-eslint/no-extra-semi",
   "@typescript-eslint/no-extra-non-null-assertion",
+  "@typescript-eslint/no-explicit-any",
   "@typescript-eslint/no-inferrable-types",
   "@typescript-eslint/no-invalid-void-type",
   "@typescript-eslint/no-loop-func",
@@ -472,6 +473,7 @@ const NATIVE_ONLY_RULE_IDS = [
 ];
 const NATIVE_RULE_IDS = [...BUILTIN_RULE_IDS, ...NATIVE_ONLY_RULE_IDS];
 const FIXABLE_BUILTIN_RULE_IDS = new Set([
+  "@typescript-eslint/no-explicit-any",
   "jest/no-deprecated-functions",
   "jest/no-jasmine-globals",
   "no-extra-semi",
@@ -479,6 +481,7 @@ const FIXABLE_BUILTIN_RULE_IDS = new Set([
   "unused-imports/no-unused-imports"
 ]);
 const SUGGESTION_BUILTIN_RULE_IDS = new Set([
+  "@typescript-eslint/no-explicit-any",
   "jest/no-focused-tests"
 ]);
 const BUILTIN_RULES = new Map(BUILTIN_RULE_IDS.map((ruleId) => [ruleId, createBuiltinRule(ruleId)]));

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -418,6 +418,7 @@ const BUILTIN_RULE_IDS = [
   "@typescript-eslint/no-duplicate-enum-values",
   "@typescript-eslint/no-extra-semi",
   "@typescript-eslint/no-extra-non-null-assertion",
+  "@typescript-eslint/no-explicit-any",
   "@typescript-eslint/no-inferrable-types",
   "@typescript-eslint/no-invalid-void-type",
   "@typescript-eslint/no-loop-func",
@@ -475,6 +476,7 @@ const NATIVE_ONLY_RULE_IDS = [
 ];
 const NATIVE_RULE_IDS = [...BUILTIN_RULE_IDS, ...NATIVE_ONLY_RULE_IDS];
 const FIXABLE_BUILTIN_RULE_IDS = new Set([
+  "@typescript-eslint/no-explicit-any",
   "jest/no-deprecated-functions",
   "jest/no-jasmine-globals",
   "no-extra-semi",
@@ -482,6 +484,7 @@ const FIXABLE_BUILTIN_RULE_IDS = new Set([
   "unused-imports/no-unused-imports"
 ]);
 const SUGGESTION_BUILTIN_RULE_IDS = new Set([
+  "@typescript-eslint/no-explicit-any",
   "jest/no-focused-tests"
 ]);
 const BUILTIN_RULES = new Map(BUILTIN_RULE_IDS.map((ruleId) => [ruleId, createBuiltinRule(ruleId)]));

--- a/npm/utoo-lint/test/no-explicit-any.test.mjs
+++ b/npm/utoo-lint/test/no-explicit-any.test.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+import { CLIEngine, Linter } from "../index.js";
+
+const require = createRequire(import.meta.url);
+const { CLIEngine: CommonJSCLIEngine, Linter: CommonJSLinter } = require("../index.cjs");
+const binary = fileURLToPath(new URL(
+  `../../../zig-out/bin/utoo-lint${process.platform === "win32" ? ".exe" : ""}`,
+  import.meta.url
+));
+const rule = "@typescript-eslint/no-explicit-any";
+
+test("ESLint APIs expose explicit-any diagnostics, suggestions, and opt-in fixes", () => {
+  for (const [Engine, RuleLinter] of [[CLIEngine, Linter], [CommonJSCLIEngine, CommonJSLinter]]) {
+    const meta = new RuleLinter().getRules().get(rule).meta;
+    assert.equal(meta.fixable, "code");
+    assert.equal(meta.hasSuggestions, true);
+    const base = { binary, useEslintrc: false };
+    const engine = new Engine({ ...base, baseConfig: { rules: { [rule]: "error" } }, fix: true });
+    const result = engine.executeOnText("export type Value = any;", "fixture.ts");
+    assert.equal(result.errorCount, 1);
+    const [message] = result.results[0].messages;
+    assert.equal(message.ruleId, rule);
+    assert.equal(message.severity, 2);
+    assert.equal(message.fix, undefined);
+    assert.deepEqual(message.suggestions.map((suggestion) => suggestion.fix.text), ["unknown", "never"]);
+    assert.equal(result.results[0].output, undefined);
+
+    const fixing = new Engine({ ...base, baseConfig: { rules: { [rule]: ["error", { fixToUnknown: true }] } }, fix: true });
+    assert.equal(fixing.executeOnText("export type Value = any;", "fixture.ts").results[0].output, "export type Value = unknown;");
+    const rest = new Engine({ ...base, baseConfig: { rules: { [rule]: ["error", { ignoreRestArgs: true }] } } });
+    assert.equal(rest.executeOnText("declare function call(...args: any[]): void;", "fixture.ts").errorCount, 0);
+  }
+});

--- a/src/core.zig
+++ b/src/core.zig
@@ -3230,6 +3230,10 @@ pub const Options = struct {
     typescript_eslint_no_extra_semi: bool = true,
     typescript_eslint_no_extra_non_null_assertion: bool = true,
     typescript_eslint_no_duplicate_enum_values: bool = true,
+    // Opt-in: adding support must not enable a new check in existing projects.
+    typescript_eslint_no_explicit_any: bool = false,
+    typescript_eslint_no_explicit_any_fix_to_unknown: bool = false,
+    typescript_eslint_no_explicit_any_ignore_rest_args: bool = false,
     typescript_eslint_no_inferrable_types: bool = true,
     typescript_eslint_no_inferrable_types_ignore_parameters: bool = false,
     typescript_eslint_no_inferrable_types_ignore_properties: bool = false,
@@ -4122,6 +4126,10 @@ pub const Options = struct {
             self.typescript_eslint_no_empty_object_type_allow_interfaces = try typescriptEslintNoEmptyObjectTypeAllowInterfacesFromConfig(value);
             self.typescript_eslint_no_empty_object_type_allow_object_types = try typescriptEslintNoEmptyObjectTypeAllowObjectTypesFromConfig(value);
             self.typescript_eslint_no_empty_object_type_allow_with_name = try typescriptEslintNoEmptyObjectTypeAllowWithNameFromConfig(value);
+        }
+        if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-explicit-any")) {
+            self.typescript_eslint_no_explicit_any_fix_to_unknown = try typescriptEslintNoExplicitAnyBoolOptionFromConfig(value, "fixToUnknown");
+            self.typescript_eslint_no_explicit_any_ignore_rest_args = try typescriptEslintNoExplicitAnyBoolOptionFromConfig(value, "ignoreRestArgs");
         }
         if (std.mem.eql(u8, cli_name, "@typescript-eslint/no-inferrable-types")) {
             self.typescript_eslint_no_inferrable_types_ignore_parameters = try typescriptEslintNoInferrableTypesBoolOptionFromConfig(value, "ignoreParameters", false);
@@ -9845,6 +9853,22 @@ pub const Options = struct {
         };
     }
 
+    fn typescriptEslintNoExplicitAnyBoolOptionFromConfig(value: std.json.Value, key: []const u8) RuleConfigError!bool {
+        const items = switch (value) {
+            .array => |array| array.items,
+            else => return false,
+        };
+        if (items.len < 2) return false;
+        const config = switch (items[1]) {
+            .object => |object| object,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+        return switch (config.get(key) orelse return false) {
+            .bool => |enabled| enabled,
+            else => return error.UnsupportedRuleConfigValue,
+        };
+    }
+
     fn typescriptEslintNoInferrableTypesBoolOptionFromConfig(value: std.json.Value, key: []const u8, default: bool) RuleConfigError!bool {
         const items = switch (value) {
             .array => |array| array.items,
@@ -10488,7 +10512,7 @@ pub fn addDiagnosticWithSuggestions(
     );
 }
 
-fn addDiagnosticWithFixesAndSuggestions(
+pub fn addDiagnosticWithFixesAndSuggestions(
     allocator: Allocator,
     diagnostics: *DiagnosticList,
     severity: Severity,

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -379,6 +379,7 @@ pub const typescript_eslint_no_loss_of_precision = @import("typescript_eslint_no
 pub const typescript_eslint_no_loop_func = @import("typescript_eslint_no_loop_func.zig");
 pub const typescript_eslint_no_misused_new = @import("typescript_eslint_no_misused_new.zig");
 pub const typescript_eslint_no_namespace = @import("typescript_eslint_no_namespace.zig");
+pub const typescript_eslint_no_explicit_any = @import("typescript_eslint_no_explicit_any.zig");
 pub const typescript_eslint_no_non_null_asserted_optional_chain = @import("typescript_eslint_no_non_null_asserted_optional_chain.zig");
 pub const typescript_eslint_no_redeclare = @import("typescript_eslint_no_redeclare.zig");
 pub const typescript_eslint_no_require_imports = @import("typescript_eslint_no_require_imports.zig");
@@ -2731,6 +2732,21 @@ const BasicVisitor = struct {
     ) Allocator.Error!traverser.Action {
         if (self.options.typescript_eslint_no_unnecessary_type_constraint) {
             try typescript_eslint_no_unnecessary_type_constraint.check(self.allocator, self.diagnostics, ctx.tree, parameter, index);
+        }
+        return .proceed;
+    }
+
+    pub fn enter_ts_any_keyword(
+        self: *BasicVisitor,
+        _: ast.TSAnyKeyword,
+        index: ast.NodeIndex,
+        ctx: *traverser.basic.Ctx,
+    ) Allocator.Error!traverser.Action {
+        if (self.options.typescript_eslint_no_explicit_any) {
+            try typescript_eslint_no_explicit_any.check(self.allocator, self.diagnostics, ctx.tree, index, ctx, .{
+                .fix_to_unknown = self.options.typescript_eslint_no_explicit_any_fix_to_unknown,
+                .ignore_rest_args = self.options.typescript_eslint_no_explicit_any_ignore_rest_args,
+            });
         }
         return .proceed;
     }

--- a/src/rules/typescript_eslint_no_explicit_any.zig
+++ b/src/rules/typescript_eslint_no_explicit_any.zig
@@ -1,0 +1,68 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+
+const ast = parser.ast;
+const Allocator = std.mem.Allocator;
+
+pub const id = "@typescript-eslint/no-explicit-any";
+
+pub const Options = struct {
+    fix_to_unknown: bool = false,
+    ignore_rest_args: bool = false,
+};
+
+pub fn check(
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    tree: *const ast.Tree,
+    index: ast.NodeIndex,
+    ctx: *parser.traverser.basic.Ctx,
+    options: Options,
+) Allocator.Error!void {
+    if (options.ignore_rest_args and isRestArgumentType(tree, ctx)) return;
+    const span = tree.span(index);
+    const fixes: []const core.Fix = if (options.fix_to_unknown) &.{.{ .span = span, .replacement = "unknown" }} else &.{};
+    try core.addDiagnosticWithFixesAndSuggestions(allocator, diagnostics, .warning, id, "Unexpected any. Specify a different type.", span, fixes, &.{
+        .{
+            .message = "Use `unknown` instead, this will force you to explicitly, and safely assert the type is correct.",
+            .fixes = &.{.{ .span = span, .replacement = "unknown" }},
+        },
+        .{
+            .message = "Use `never` instead, this is useful when instantiating generic type parameters that you don't need to know the type of.",
+            .fixes = &.{.{ .span = span, .replacement = "never" }},
+        },
+    });
+}
+
+fn isRestArgumentType(tree: *const ast.Tree, ctx: *parser.traverser.basic.Ctx) bool {
+    // ESLint omits parenthesized types from this ancestry. FormalParameters is
+    // an extra Yuku wrapper; verify its rest slot to exclude destructuring.
+    var ancestors: [5]ast.NodeIndex = @splat(.null);
+    var count: usize = 0;
+    var depth: usize = 1;
+    while (count < ancestors.len) : (depth += 1) {
+        const ancestor = ctx.path.ancestor(depth) orelse break;
+        if (tree.data(ancestor) == .ts_parenthesized_type) continue;
+        ancestors[count] = ancestor;
+        count += 1;
+    }
+    if (isFunctionRest(tree, ancestors[2], ancestors[3])) return true;
+    if (!isFunctionRest(tree, ancestors[3], ancestors[4]) or ancestors[1] == .null) return false;
+    return switch (tree.data(ancestors[1])) {
+        .ts_type_operator => |operator| operator.operator == .readonly,
+        .ts_type_reference => |reference| switch (tree.data(reference.type_name)) {
+            .identifier_reference => |name| std.mem.eql(u8, tree.string(name.name), "Array") or std.mem.eql(u8, tree.string(name.name), "ReadonlyArray"),
+            else => false,
+        },
+        else => false,
+    };
+}
+
+fn isFunctionRest(tree: *const ast.Tree, rest: ast.NodeIndex, parent: ast.NodeIndex) bool {
+    if (rest == .null or parent == .null or tree.data(rest) != .binding_rest_element) return false;
+    return switch (tree.data(parent)) {
+        .formal_parameters => |parameters| parameters.rest == rest,
+        else => false,
+    };
+}

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1419,6 +1419,7 @@ comptime {
 
 comptime {
     _ = @import("rules/typescript_eslint_no_namespace.zig");
+    _ = @import("rules/typescript_eslint_no_explicit_any.zig");
 }
 
 comptime {

--- a/tests/rules/typescript_eslint_no_explicit_any.zig
+++ b/tests/rules/typescript_eslint_no_explicit_any.zig
@@ -1,0 +1,77 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+
+test "reports explicit any types but not identifiers or strings named any" {
+    const source =
+        \\export type Alias = any;
+        \\export function convert(value: any): any { return value; }
+        \\export type Values = Array<any>;
+        \\export const any = "any";
+    ;
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("@typescript-eslint/no-explicit-any", .{ .string = "error" });
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 4), result.diagnostics.len);
+    for (result.diagnostics) |diagnostic| {
+        try std.testing.expectEqualStrings("@typescript-eslint/no-explicit-any", diagnostic.rule_id);
+        try std.testing.expectEqualStrings("Unexpected any. Specify a different type.", diagnostic.message);
+        try std.testing.expectEqualStrings("any", source[diagnostic.span.start..diagnostic.span.end]);
+        try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+        try std.testing.expectEqual(@as(usize, 2), diagnostic.suggestions.len);
+    }
+}
+
+test "fixToUnknown is opt-in and keeps editor suggestions" {
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "[\"error\",{\"fixToUnknown\":true}]", .{});
+    defer config.deinit();
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("@typescript-eslint/no-explicit-any", config.value);
+    var result = try lint.lintSource(std.testing.allocator, "type Value = any;", "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 1), result.diagnostics.len);
+    try std.testing.expectEqual(@as(usize, 1), result.diagnostics[0].fixes.len);
+    try std.testing.expectEqualStrings("unknown", result.diagnostics[0].fixes[0].replacement);
+    try std.testing.expectEqual(@as(usize, 2), result.diagnostics[0].suggestions.len);
+}
+
+test "ignoreRestArgs only exempts direct rest parameter array types" {
+    const source =
+        \\declare function a(...args: any[]): void;
+        \\declare function b(...args: readonly any[]): void;
+        \\declare function c(...args: Array<any>): void;
+        \\declare function d(...args: ReadonlyArray<any>): void;
+        \\type Callback = (...args: any[]) => void;
+        \\type Constructor = new (...args: any[]) => object;
+        \\interface Callable {
+        \\  (...args: any[]): void;
+        \\  new (...args: any[]): object;
+        \\  run(...args: any[]): void;
+        \\}
+        \\const arrow = (...args: any[]) => {};
+        \\class Methods { run(...args: any[]) {} }
+        \\function ordinary(value: any, ...nested: any[][]) {}
+        \\function other(...values: Promise<any>) {}
+    ;
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "[\"error\",{\"ignoreRestArgs\":true}]", .{});
+    defer config.deinit();
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("@typescript-eslint/no-explicit-any", config.value);
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 3), result.diagnostics.len);
+}
+
+test "scalar configuration resets explicit-any options and disabling the rule is respected" {
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "[\"error\",{\"fixToUnknown\":true,\"ignoreRestArgs\":true}]", .{});
+    defer config.deinit();
+    var options = lint.Options.allDisabled();
+    try options.setByRuleConfigValue("@typescript-eslint/no-explicit-any", config.value);
+    try options.setByRuleConfigValue("@typescript-eslint/no-explicit-any", .{ .string = "error" });
+    try std.testing.expect(!options.typescript_eslint_no_explicit_any_fix_to_unknown);
+    try std.testing.expect(!options.typescript_eslint_no_explicit_any_ignore_rest_args);
+    try options.setByRuleConfigValue("@typescript-eslint/no-explicit-any", .{ .string = "off" });
+    var result = try lint.lintSource(std.testing.allocator, "type Value = any;", "fixture.ts", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), result.diagnostics.len);
+}


### PR DESCRIPTION
## Summary

- Implement `@typescript-eslint/no-explicit-any` using TypeScript AST keyword nodes rather than text matching.
- Support `ignoreRestArgs` and opt-in `fixToUnknown`; retain both `unknown` and `never` editor suggestions.
- Expose the rule and its fix/suggestion metadata in ESM and CommonJS ESLint APIs.
- Keep the rule disabled in native defaults: existing projects gain no new check unless their configuration enables it.

## Context

The project-config investigation behind #1200 found a configured rule that was not implemented by the native engine. Config discovery alone cannot honor `@typescript-eslint/no-explicit-any`. This PR fills that independent gap and does not change Umi integration or business code.

## Local validation

- Combined local verification of #1199, #1200, and #1201: the unchanged Bigfish project's `tnpm run lint` reports 2 errors instead of 8. Only the two genuine missing-JSX-key diagnostics remain (exit code 1).
- With the real project config, `export const debugValue: any = 1;` produces one error at a regular source filename and zero at its configured DebugView exemption. The combined targeted API suite passes all 9 tests.

- Regression tests observed failing for unknown rule, missing opt-in fix, and missing rest-argument exemption before their respective implementations.
- `zig build test --summary all`: 2157/2157 tests and all 16 rule snapshots passed.
- `zig build` and formatting checks passed.
- Full npm suite: 158 tests plus TypeScript checks passed.
- 40 differential cases against the real project's installed `@typescript-eslint/eslint-plugin` 5.62.0: identical diagnostics and locations, with `ignoreRestArgs` both enabled and disabled.
- ESM/CommonJS tests verify severity, editor suggestions, opt-in autofix output, and rest-argument handling.

Rule behavior and options follow [the TypeScript ESLint rule documentation](https://typescript-eslint.io/rules/no-explicit-any/).
