### PR TITLE
feat: add react-hooks/use-memo validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ visible without blocking adoption:
 | `error` | `react-hooks/rules-of-hooks`, `react/jsx-key`, `react/no-children-prop`, `react/no-danger-with-children`, `react/void-dom-elements-no-children`, `no-script-url`, `promise/no-nesting` |
 | `warn` | `react-hooks/exhaustive-deps`, `react/no-array-index-key`, `react/no-unstable-nested-components`, `react/no-forward-ref`, `unused-imports/no-unused-imports`, `@typescript-eslint/no-unused-vars`, `@typescript-eslint/ban-types` |
 
+React Compiler-related `react-hooks/use-memo`
+checks are also available as opt-in rules. See
+[configuration and coverage](docs/configuration.md#react-compiler-related-checks).
+
 Override project-specific rules after spreading `frontend.rules`, and append
 framework-generated directories to `frontend.ignores`, as shown above.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,3 +271,27 @@ For one-off focused runs, `--rules` disables every rule first, then enables only
 ```bash
 npx utoo-lint --rules=no-debugger,react/jsx-no-target-blank src
 ```
+
+## React Compiler-related checks
+
+Enable the native React Compiler-related checks explicitly in `utlint.config.json`:
+
+```json
+{
+  "rules": {
+    "react-hooks/use-memo": "error"
+  }
+}
+```
+
+These rules are disabled by default and are not added to the `frontend` preset.
+They run in both native and WebAssembly builds without installing React Compiler.
+They cover a documented subset of the upstream rules; enabling them does not prove
+that a component can be compiled. See [rule status](rule-status.md#react-hooks-rules)
+for supported patterns and limitations.
+
+Rule names follow React main at `e92bda78750136493cb324e98df1726f62ba8e92`: `use-memo`
+checks callback signatures and captured assignments; `void-use-memo` checks missing
+returns and unused results and is in upstream `recommended-latest`. The selected
+upstream fixtures and their coverage boundaries are recorded in each rule’s
+`tests/snapshots/specs/react-hooks/<rule>/UPSTREAM.md`.

--- a/docs/configuration.zh-CN.md
+++ b/docs/configuration.zh-CN.md
@@ -207,3 +207,23 @@ npx utoo-lint --config=utlint.config.json --no-console=off src
 ```bash
 npx utoo-lint --rules=no-debugger,react/jsx-no-target-blank src
 ```
+
+## React Compiler 相关检查
+
+在 `utlint.config.json` 中显式开启原生 React Compiler 相关检查：
+
+```json
+{
+  "rules": {
+    "react-hooks/use-memo": "error"
+  }
+}
+```
+
+这些规则默认关闭，`frontend` 预设也不会自动开启；原生和 WebAssembly 构建均支持，
+无需安装 React Compiler。当前覆盖上游规则的部分场景，通过检查不代表组件一定能被 Compiler 编译。
+支持范围与限制见[规则状态](rule-status.zh-CN.md)。
+
+规则划分参照 React 主线 `e92bda78750136493cb324e98df1726f62ba8e92`：`use-memo` 检查回调签名和捕获变量赋值；
+`void-use-memo` 检查缺失返回值和未使用的结果，上游将其放在 `recommended-latest` 中。
+每条规则的 `tests/snapshots/specs/react-hooks/<rule>/UPSTREAM.md` 记录选取的上游测试与覆盖边界。

--- a/docs/rule-status.md
+++ b/docs/rule-status.md
@@ -367,6 +367,16 @@ instead of being rewritten.
 | --- | --- |
 | [`react-hooks/exhaustive-deps`](https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps) | Implements dependency-array validation for built-in hooks and `additionalHooks` literal, alternation, anchor, and wildcard patterns; reports missing, duplicate, unnecessary, complex, and unstable dependencies without type information |
 | [`react-hooks/rules-of-hooks`](https://legacy.reactjs.org/docs/hooks-rules.html) | Implemented for top-level, ordinary function, class method, callback, conditional branch, and loop checks |
+| [`react-hooks/use-memo`](https://react.dev/reference/eslint-plugin-react-hooks/lints/use-memo) | Opt-in; rejects parameters, async/generator callbacks, and direct writes to captured bindings in inline and statically resolved named `useMemo` callbacks. Callback-local reassignment is allowed; nested closure writes are not analyzed |
+
+These opt-in checks are native approximations of React Compiler-related
+lints, not the React Compiler diagnostic engine. React imports (ES modules and literal `require("react")`), stable local aliases,
+and local shadowing are resolved. Component/hook names and React `memo`/`forwardRef`
+wrappers identify render functions. Named memo callbacks are connected to render
+invocations. Dynamic reassignment, arbitrary interprocedural analysis, and compiler
+data-flow/configuration analysis are not covered. Rules such as
+`refs`, `immutability`, `preserve-manual-memoization`, `config`, and `gating` remain
+unsupported. See [configuration](configuration.md#react-compiler-related-checks).
 
 ## Unused Imports rules
 

--- a/docs/rule-status.zh-CN.md
+++ b/docs/rule-status.zh-CN.md
@@ -366,6 +366,13 @@
 | --- | --- |
 | [`react-hooks/exhaustive-deps`](https://react.dev/reference/eslint-plugin-react-hooks/lints/exhaustive-deps) | 已实现内置 Hook 和 `additionalHooks` 字面量、分支、锚点及通配符模式的依赖数组验证；无需类型信息即可报告缺失、重复、不必要、复杂和不稳定的依赖 |
 | [`react-hooks/rules-of-hooks`](https://legacy.reactjs.org/docs/hooks-rules.html) | 已实现顶层、普通函数、类方法、回调、条件分支和循环检查 |
+| [`react-hooks/use-memo`](https://react.dev/reference/eslint-plugin-react-hooks/lints/use-memo) | 按需开启；检查内联和可静态解析的具名 `useMemo` 回调的参数、async/generator 和对捕获变量的直接重赋值；允许回调内部局部变量重赋值，暂不分析嵌套闭包写入 |
+
+这些按需开启的规则是 React Compiler 相关检查的原生实现子集，并未运行 React Compiler 诊断引擎。
+支持 ES 模块及字面量 `require("react")` 导入、稳定局部别名和局部变量遮蔽，通过组件/Hook 命名以及 React `memo`/`forwardRef` 包装识别渲染函数。
+具名 memo 回调会关联到渲染时的调用点；暂不覆盖动态重赋值、任意跨函数调用分析以及 Compiler 的数据流和配置分析。
+`refs`、`immutability`、`preserve-manual-memoization`、`config`、`gating` 等规则仍不支持。
+用法见[配置](configuration.zh-CN.md#react-compiler-相关检查)。
 
 ## Unused Imports 规则
 

--- a/npm/utoo-lint/index.cjs
+++ b/npm/utoo-lint/index.cjs
@@ -397,6 +397,7 @@ const BUILTIN_RULE_IDS = [
   "react/void-dom-elements-no-children",
   "react-hooks/exhaustive-deps",
   "react-hooks/rules-of-hooks",
+  "react-hooks/use-memo",
   "unused-imports/no-unused-imports",
   "@typescript-eslint/adjacent-overload-signatures",
   "@typescript-eslint/array-type",

--- a/npm/utoo-lint/index.js
+++ b/npm/utoo-lint/index.js
@@ -400,6 +400,7 @@ const BUILTIN_RULE_IDS = [
   "react/void-dom-elements-no-children",
   "react-hooks/exhaustive-deps",
   "react-hooks/rules-of-hooks",
+  "react-hooks/use-memo",
   "unused-imports/no-unused-imports",
   "@typescript-eslint/adjacent-overload-signatures",
   "@typescript-eslint/array-type",

--- a/npm/utoo-lint/test/config-loading.test.mjs
+++ b/npm/utoo-lint/test/config-loading.test.mjs
@@ -3872,3 +3872,52 @@ for (const filename of ["utlint.config.ts", "utlint.config.json"]) {
     assert.equal(result.status, 0, result.stderr);
   });
 }
+
+test("React Compiler use-memo supports ESM/CommonJS configuration and suppression", (t) => {
+  const project = createProject(t);
+  const ruleId = "react-hooks/use-memo";
+  write(join(project, "utlint.config.json"), JSON.stringify({ rules: { [ruleId]: "error" } }));
+  const source = "import {useMemo as calculate} from 'react'; function Component() { return calculate(async (value) => value, []); }";
+  const options = { cwd: project, binary: testBinary(), encoding: "utf8" };
+  for (const extension of ["js", "jsx", "ts", "tsx"]) {
+    const sourcePath = write(join(project, `component.${extension}`), source);
+    for (const execute of [runCli, commonJSRunCli]) {
+      const result = execute(["--json", sourcePath], options);
+      assert.equal(result.status, 1, result.stderr);
+      const diagnostics = JSON.parse(result.stdout).diagnostics;
+      assert.equal(diagnostics.length, 2);
+      assert.ok(diagnostics.every((item) => item.ruleId === ruleId && item.severity === "error" && item.fixes.length === 0));
+    }
+  }
+  const sourcePath = write(join(project, "suppressed.js"), `// utlint-ignore-all ${ruleId}: fixture\n${source}`);
+  for (const execute of [runCli, commonJSRunCli]) {
+    const result = execute(["--json", sourcePath], options);
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout).diagnostics, []);
+  }
+});
+
+test("migrator recognizes React Compiler use-memo", (t) => {
+  const project = createProject(t);
+  const ruleId = "react-hooks/use-memo";
+  const config = write(join(project, ".eslintrc.json"), JSON.stringify({ rules: { [ruleId]: "error", "react-hooks/refs": "error" } }));
+  const result = spawnSync(process.execPath, [cliPath, "migrate", "eslint", `--from=${config}`, "--print", "--report=json"], { cwd: project, encoding: "utf8" });
+  assert.equal(result.status, 1, result.stderr);
+  const report = JSON.parse(result.stderr);
+  assert.deepEqual(report.supportedRules, [ruleId]);
+  assert.deepEqual(report.unsupportedRules, ["react-hooks/refs"]);
+});
+
+test("React Compiler use-memo resolves CommonJS and indirect values through both wrappers", (t) => {
+  const project = createProject(t);
+  const ruleId = "react-hooks/use-memo";
+  write(join(project, "utlint.config.json"), JSON.stringify({ rules: { [ruleId]: "error" } }));
+  const sourcePath = write(join(project, "component.tsx"), "const {useMemo: memo} = require('react'); const calc = async value => value; function Component() { return memo(calc, []); }");
+  for (const execute of [runCli, commonJSRunCli]) {
+    const result = execute(["--json", sourcePath], { cwd: project, binary: testBinary(), encoding: "utf8" });
+    assert.equal(result.status, 1, result.stderr);
+    const diagnostics = JSON.parse(result.stdout).diagnostics;
+    assert.equal(diagnostics.length, 2);
+    assert.ok(diagnostics.every((item) => item.ruleId === ruleId));
+  }
+});

--- a/src/core.zig
+++ b/src/core.zig
@@ -3162,6 +3162,7 @@ pub const Options = struct {
     react_hooks_exhaustive_deps: bool = true,
     react_hooks_exhaustive_deps_additional_hooks: ReactHooksAdditionalHooksPattern = .{},
     react_hooks_rules_of_hooks: bool = true,
+    react_hooks_use_memo: bool = false,
     unused_imports_no_unused_imports: bool = false,
     radix: bool = true,
     radix_style: RadixStyle = .always,

--- a/src/root.zig
+++ b/src/root.zig
@@ -264,6 +264,7 @@ fn hasSemanticRules(options: Options) bool {
         options.no_async_promise_executor or
         options.alipay_ant_exhaustive_deps or
         options.react_hooks_exhaustive_deps or
+        options.react_hooks_use_memo or
         options.alipay_ant_prefer_click_with_debounce or
         options.no_buffer_constructor or
         options.no_console or

--- a/src/rules/react_hooks_helpers.zig
+++ b/src/rules/react_hooks_helpers.zig
@@ -1,0 +1,297 @@
+const std = @import("std");
+const parser = @import("parser");
+const ast = parser.ast;
+pub const SymbolTable = @import("../semantic_compat.zig").SymbolTable;
+
+pub fn unwrap(tree: *const ast.Tree, node: ast.NodeIndex) ast.NodeIndex {
+    var current = node;
+    while (current != .null) {
+        current = switch (tree.data(current)) {
+            .parenthesized_expression => |e| e.expression,
+            .chain_expression => |e| e.expression,
+            .ts_as_expression => |e| e.expression,
+            .ts_satisfies_expression => |e| e.expression,
+            .ts_non_null_expression => |e| e.expression,
+            .ts_type_assertion => |e| e.expression,
+            else => return current,
+        };
+    }
+    return current;
+}
+
+pub fn name(tree: *const ast.Tree, node: ast.NodeIndex) ?[]const u8 {
+    if (node == .null) return null;
+    return switch (tree.data(unwrap(tree, node))) {
+        .binding_identifier => |n| tree.string(n.name),
+        .identifier_reference => |n| tree.string(n.name),
+        .identifier_name => |n| tree.string(n.name),
+        .string_literal => |n| tree.string(n.value),
+        else => null,
+    };
+}
+
+pub fn memberName(tree: *const ast.Tree, member: ast.MemberExpression) ?[]const u8 {
+    if (member.computed and tree.data(member.property) != .string_literal) return null;
+    return name(tree, member.property);
+}
+
+pub const Property = union(enum) { field: []const u8, index: usize };
+pub const Value = struct {
+    node: ast.NodeIndex,
+    properties: [16]Property = undefined,
+    len: usize = 0,
+
+    fn append(self: *Value, property: Property) bool {
+        if (self.len == self.properties.len) return false;
+        self.properties[self.len] = property;
+        self.len += 1;
+        return true;
+    }
+};
+pub const MemoCall = struct { node: ast.NodeIndex, callback: ast.NodeIndex };
+
+pub const Context = struct {
+    tree: *const ast.Tree,
+    symbols: SymbolTable,
+    memo_calls: std.ArrayList(MemoCall) = .empty,
+
+    pub fn init(allocator: std.mem.Allocator, tree: *const ast.Tree, symbols: SymbolTable) std.mem.Allocator.Error!Context {
+        var context = Context{ .tree = tree, .symbols = symbols };
+        errdefer context.memo_calls.deinit(allocator);
+        const Collector = struct {
+            context: *Context,
+            allocator: std.mem.Allocator,
+            pub fn enter_call_expression(self: *@This(), call: ast.CallExpression, node: ast.NodeIndex, _: *parser.traverser.basic.Ctx) std.mem.Allocator.Error!parser.traverser.Action {
+                if (call.arguments.len > 0 and self.context.isReactApi(call.callee, "useMemo")) {
+                    if (self.context.resolve(self.context.tree.extra(call.arguments)[0])) |value| {
+                        if (value.len == 0 and (self.context.tree.data(value.node) == .function or self.context.tree.data(value.node) == .arrow_function_expression)) {
+                            try self.context.memo_calls.append(self.allocator, .{ .node = node, .callback = value.node });
+                        }
+                    }
+                }
+                return .proceed;
+            }
+        };
+        var collector = Collector{ .context = &context, .allocator = allocator };
+        try parser.traverser.basic.traverse(Collector, tree, &collector);
+        return context;
+    }
+
+    // Follow only stable bindings. Bounded paths also terminate cyclic aliases.
+    pub fn resolve(self: Context, node: ast.NodeIndex) ?Value {
+        return self.resolveDepth(node, 0);
+    }
+
+    fn resolveDepth(self: Context, expression: ast.NodeIndex, depth: usize) ?Value {
+        if (depth >= 64) return null;
+        const node = unwrap(self.tree, expression);
+        if (node == .null) return null;
+        if (self.tree.data(node) == .member_expression) {
+            const member = self.tree.data(node).member_expression;
+            const property = memberName(self.tree, member) orelse return null;
+            var value = self.resolveDepth(member.object, depth + 1) orelse return null;
+            if (!value.append(.{ .field = property })) return null;
+            return value;
+        }
+        if (self.tree.data(node) != .identifier_reference) return .{ .node = node };
+        const symbol = self.symbols.symbolOf(node) orelse return .{ .node = node };
+        var uses = self.symbols.symbolUses(symbol);
+        while (uses.next()) |use| {
+            if (self.symbols.isWriteReference(self.symbols.model.referenceOf(use).?)) return null;
+        }
+        if (self.symbols.getSymbol(symbol).flags.import) return .{ .node = node };
+        const declarations = self.symbols.symbolDecls(symbol);
+        if (declarations.len != 1) return null;
+        var current = declarations[0];
+        var path: [16]Property = undefined;
+        var count: usize = 0;
+        while (self.symbols.parentOf(current)) |parent| {
+            switch (self.tree.data(parent)) {
+                .function => return .{ .node = parent },
+                .variable_declarator => |variable| {
+                    if (variable.id != current) return null;
+                    var value = self.resolveDepth(variable.init, depth + 1) orelse return null;
+                    while (count > 0) {
+                        count -= 1;
+                        if (!value.append(path[count])) return null;
+                    }
+                    return value;
+                },
+                .array_pattern => |pattern| {
+                    if (count == path.len) return null;
+                    var found = false;
+                    for (self.tree.extra(pattern.elements), 0..) |element, index| {
+                        if (element == current) {
+                            path[count] = .{ .index = index };
+                            count += 1;
+                            found = true;
+                            break;
+                        }
+                    }
+                    if (!found) return null;
+                },
+                .binding_property => |property| {
+                    if (property.value != current or count == path.len or
+                        (property.computed and self.tree.data(property.key) != .string_literal)) return null;
+                    path[count] = .{ .field = name(self.tree, property.key) orelse return null };
+                    count += 1;
+                },
+                .object_pattern => {},
+                else => return null,
+            }
+            current = parent;
+        }
+        return null;
+    }
+
+    pub fn isMemoCallback(self: Context, node: ast.NodeIndex) bool {
+        for (self.memo_calls.items) |call| {
+            if (call.callback == node and self.renderOwner(call.node) != null) return true;
+        }
+        return false;
+    }
+
+    // Resolve React imports by symbol, so aliases work and local shadows do not.
+    // Stable local aliases and literal CommonJS imports use the same provenance.
+    // Also accept conventional unresolved useX/React names, as rules-of-hooks does.
+    pub fn isReactApi(self: Context, callee: ast.NodeIndex, api: []const u8) bool {
+        const value = self.resolve(callee) orelse return false;
+        if (value.len == 0) return self.isReactImport(value.node, api);
+        if (value.len != 1 or value.properties[0] != .field or !std.mem.eql(u8, value.properties[0].field, api)) return false;
+        if (self.isReactImport(value.node, null)) return true;
+        if (self.tree.data(value.node) != .call_expression) return false;
+        const call = self.tree.data(value.node).call_expression;
+        const require = unwrap(self.tree, call.callee);
+        return call.arguments.len == 1 and self.tree.data(self.tree.extra(call.arguments)[0]) == .string_literal and
+            self.symbols.isUnresolvedReference(require) and
+            std.mem.eql(u8, name(self.tree, require) orelse "", "require") and
+            std.mem.eql(u8, name(self.tree, self.tree.extra(call.arguments)[0]) orelse "", "react");
+    }
+
+    fn isReactImport(self: Context, node: ast.NodeIndex, api: ?[]const u8) bool {
+        if (self.tree.data(node) != .identifier_reference) return false;
+        const symbol = self.symbols.symbolOf(node) orelse {
+            return self.symbols.isUnresolvedReference(node) and
+                std.mem.eql(u8, name(self.tree, node) orelse return false, api orelse "React");
+        };
+        if (!self.symbols.getSymbol(symbol).flags.import) return false;
+        for (self.symbols.symbolDecls(symbol)) |declaration| {
+            var current = declaration;
+            var matches = false;
+            while (true) {
+                switch (self.tree.data(current)) {
+                    .import_specifier => |s| {
+                        matches = s.import_kind != .type and api != null and
+                            std.mem.eql(u8, name(self.tree, s.imported) orelse "", api.?);
+                    },
+                    .import_default_specifier, .import_namespace_specifier => matches = api == null,
+                    .import_declaration => |d| return matches and d.import_kind != .type and
+                        std.mem.eql(u8, name(self.tree, d.source) orelse "", "react"),
+                    else => {},
+                }
+                current = self.symbols.parentOf(current) orelse break;
+            }
+        }
+        return false;
+    }
+
+    pub fn outerExpression(self: Context, node: ast.NodeIndex) ast.NodeIndex {
+        var current = node;
+        while (self.symbols.parentOf(current)) |parent| {
+            if (unwrap(self.tree, parent) != node) break;
+            current = parent;
+        }
+        return current;
+    }
+
+    pub fn callbackCall(self: Context, node: ast.NodeIndex) ?ast.CallExpression {
+        const outer = self.outerExpression(node);
+        const parent = self.symbols.parentOf(outer) orelse return null;
+        const call = switch (self.tree.data(parent)) {
+            .call_expression => |c| c,
+            else => return null,
+        };
+        if (call.arguments.len == 0 or self.tree.extra(call.arguments)[0] != outer) return null;
+        return call;
+    }
+
+    pub fn nearestFunction(self: Context, node: ast.NodeIndex) ?ast.NodeIndex {
+        var current = node;
+        while (self.symbols.parentOf(current)) |parent| {
+            switch (self.tree.data(parent)) {
+                .function, .arrow_function_expression => return parent,
+                .class, .method_definition, .property_definition => return null,
+                else => current = parent,
+            }
+        }
+        return null;
+    }
+
+    // Deferred callbacks (events, effects, lazy initializers) are boundaries.
+    // Resolved useMemo callbacks and synchronous IIFEs execute during render.
+    pub fn renderOwner(self: Context, node: ast.NodeIndex) ?ast.NodeIndex {
+        return self.renderOwnerDepth(node, undefined, 0);
+    }
+
+    fn renderOwnerDepth(self: Context, node: ast.NodeIndex, ancestors: [32]ast.NodeIndex, depth: usize) ?ast.NodeIndex {
+        if (depth >= ancestors.len) return null;
+        var path = ancestors;
+        var current = node;
+        while (self.nearestFunction(current)) |function| {
+            for (ancestors[0..depth]) |ancestor| {
+                if (ancestor == function) return null;
+            }
+            path[depth] = function;
+            if (self.isReactFunction(function)) return function;
+            const async_or_generator = switch (self.tree.data(function)) {
+                .function => |f| f.async or f.generator,
+                .arrow_function_expression => |f| f.async,
+                else => unreachable,
+            };
+            if (async_or_generator) return null;
+            if (self.callbackCall(function)) |call| {
+                if (self.isReactApi(call.callee, "useMemo")) {
+                    current = function;
+                    continue;
+                }
+            }
+            const outer = self.outerExpression(function);
+            if (self.symbols.parentOf(outer)) |parent| {
+                if (self.tree.data(parent) == .call_expression and self.tree.data(parent).call_expression.callee == outer) {
+                    current = function;
+                    continue;
+                }
+            }
+            for (self.memo_calls.items) |call| {
+                if (call.callback == function) {
+                    if (self.renderOwnerDepth(call.node, path, depth + 1)) |owner| return owner;
+                }
+            }
+            return null;
+        }
+        return null;
+    }
+
+    fn isReactFunction(self: Context, node: ast.NodeIndex) bool {
+        const outer = self.outerExpression(node);
+        const parent = self.symbols.parentOf(outer) orelse return false;
+        if (self.tree.data(parent) == .method_definition or self.tree.data(parent) == .object_property or
+            self.tree.data(parent) == .property_definition) return false;
+        // A named callback is still deferred; only React wrappers define components.
+        if (self.callbackCall(node)) |call| {
+            return self.isReactApi(call.callee, "memo") or self.isReactApi(call.callee, "forwardRef");
+        }
+        if (self.tree.data(parent) == .call_expression and self.tree.data(parent).call_expression.callee != outer) return false;
+        const function_name = switch (self.tree.data(parent)) {
+            .variable_declarator => |d| name(self.tree, d.id),
+            .assignment_expression => |a| name(self.tree, a.left),
+            else => switch (self.tree.data(node)) {
+                .function => |f| name(self.tree, f.id),
+                else => null,
+            },
+        } orelse return false;
+        return function_name.len > 0 and (std.ascii.isUpper(function_name[0]) or
+            (std.mem.startsWith(u8, function_name, "use") and function_name.len > 3 and
+                (std.ascii.isUpper(function_name[3]) or std.ascii.isDigit(function_name[3]))));
+    }
+};

--- a/src/rules/react_hooks_use_memo.zig
+++ b/src/rules/react_hooks_use_memo.zig
@@ -1,0 +1,62 @@
+const std = @import("std");
+const parser = @import("parser");
+const core = @import("../core.zig");
+const helpers = @import("react_hooks_helpers.zig");
+const ast = parser.ast;
+const traverser = parser.traverser;
+const Allocator = std.mem.Allocator;
+
+pub const id = "react-hooks/use-memo";
+
+pub fn run(allocator: Allocator, diagnostics: *core.DiagnosticList, tree: *const ast.Tree, symbols: helpers.SymbolTable) Allocator.Error!void {
+    var visitor = Visitor{ .allocator = allocator, .diagnostics = diagnostics, .context = try helpers.Context.init(allocator, tree, symbols) };
+    defer visitor.context.memo_calls.deinit(allocator);
+    try traverser.basic.traverse(Visitor, tree, &visitor);
+    var references = symbols.iterReferences();
+    while (references.next()) |entry| {
+        if (!symbols.isWriteReference(entry.id)) continue;
+        const function = visitor.context.nearestFunction(entry.reference.node) orelse continue;
+        if (!visitor.isMemoCallback(function)) continue;
+        const symbol = symbols.referenceSymbol(entry.id);
+        if (symbol == .none) continue;
+        const declarations = symbols.symbolDecls(symbol);
+        if (declarations.len == 0) continue;
+        var outside = true;
+        for (declarations) |declaration| {
+            if (visitor.context.nearestFunction(declaration) == function) outside = false;
+        }
+        if (outside) try visitor.report(entry.reference.node, "useMemo callbacks must not reassign variables declared outside the callback.");
+    }
+}
+
+const Visitor = struct {
+    allocator: Allocator,
+    diagnostics: *core.DiagnosticList,
+    context: helpers.Context,
+
+    fn isMemoCallback(self: *const Visitor, node: ast.NodeIndex) bool {
+        return self.context.isMemoCallback(node);
+    }
+
+    fn check(self: *Visitor, node: ast.NodeIndex, params_node: ast.NodeIndex, async_or_generator: bool) Allocator.Error!traverser.Action {
+        if (!self.isMemoCallback(node)) return .proceed;
+        const params = self.context.tree.data(params_node).formal_parameters;
+        if (params.items.len > 0 or params.rest != .null) {
+            try self.report(params_node, "useMemo callbacks must not accept parameters; capture the values needed for the calculation instead.");
+        }
+        if (async_or_generator) try self.report(node, "useMemo callbacks must be synchronous and must not be async or generator functions.");
+        return .proceed;
+    }
+
+    pub fn enter_function(self: *Visitor, function: ast.Function, node: ast.NodeIndex, _: *traverser.basic.Ctx) Allocator.Error!traverser.Action {
+        return self.check(node, function.params, function.async or function.generator);
+    }
+
+    pub fn enter_arrow_function_expression(self: *Visitor, arrow: ast.ArrowFunctionExpression, node: ast.NodeIndex, _: *traverser.basic.Ctx) Allocator.Error!traverser.Action {
+        return self.check(node, arrow.params, arrow.async);
+    }
+
+    fn report(self: *Visitor, node: ast.NodeIndex, message: []const u8) Allocator.Error!void {
+        try core.addDiagnostic(self.allocator, self.diagnostics, .@"error", id, message, self.context.tree.span(node));
+    }
+};

--- a/src/rules/root.zig
+++ b/src/rules/root.zig
@@ -340,6 +340,7 @@ pub const react_self_closing_comp = @import("react_self_closing_comp.zig");
 pub const react_void_dom_elements_no_children = @import("react_void_dom_elements_no_children.zig");
 pub const react_hooks_exhaustive_deps = @import("react_hooks_exhaustive_deps.zig");
 pub const react_hooks_rules_of_hooks = @import("react_hooks_rules_of_hooks.zig");
+pub const react_hooks_use_memo = @import("react_hooks_use_memo.zig");
 pub const radix = @import("radix.zig");
 pub const require_await = @import("require_await.zig");
 pub const require_atomic_updates = @import("require_atomic_updates.zig");
@@ -884,6 +885,10 @@ fn runSemanticBeforeIo(
             semantic_result.symbol_table,
             options.react_hooks_exhaustive_deps_additional_hooks,
         );
+    }
+
+    if (options.react_hooks_use_memo) {
+        try react_hooks_use_memo.run(allocator, diagnostics, tree, semantic_result.symbol_table);
     }
 
     if (options.react_no_forward_ref) {

--- a/tests/all.zig
+++ b/tests/all.zig
@@ -1291,6 +1291,7 @@ comptime {
 
 comptime {
     _ = @import("rules/react_hooks_rules_of_hooks.zig");
+    _ = @import("rules/react_hooks_use_memo.zig");
 }
 
 comptime {

--- a/tests/rules/react_hooks_use_memo.zig
+++ b/tests/rules/react_hooks_use_memo.zig
@@ -1,0 +1,109 @@
+const std = @import("std");
+const lint = @import("utoo_lint");
+const helpers = @import("../helpers.zig");
+
+test "rejects callback parameters including destructuring and rest" {
+    try check(
+        \\function Component({value}) { return [useMemo(x => value, []), useMemo(({x}) => x, []), useMemo((...xs) => xs, [])]; }
+    , 3);
+}
+
+test "rejects async and generator callbacks" {
+    try check(
+        \\import React, {useMemo as calculate} from 'react';
+        \\function Component() { return [calculate(async () => 1, []), React.useMemo(async function() { return 1; }, []), useMemo(function* () { yield 1; }, [])]; }
+    , 3);
+}
+
+test "reports captured writes but permits callback-local writes" {
+    try check(
+        \\function Component({value}) { let count = 0; return useMemo(() => { let local = 0; local++; count++; value = 2; return local; }, []); }
+    , 2);
+}
+
+test "respects shadowed captured names and nested deferred callbacks" {
+    try check(
+        \\function Component() { let count = 0; return useMemo(() => { let count = 1; count++; return () => { count++; }; }, []); }
+    , 0);
+}
+
+test "respects foreign imports local hooks and ordinary utilities" {
+    try check(
+        \\import {useMemo as calculate} from 'other';
+        \\function Component(useMemo) { return [useMemo(async x => x, []), calculate(async x => x, [])]; }
+        \\function utility() { return React.useMemo(async x => x, []); }
+    , 0);
+}
+
+test "supports TypeScript wrappers" {
+    try check(
+        \\import {useMemo as calculate} from 'react';
+        \\function useValue() { return (calculate as any)(((x: number) => x) as any, []); }
+    , 1);
+}
+
+test "leaves no-value and unused-result diagnostics to void-use-memo" {
+    try check(
+        \\function Component() { useMemo(() => {}, []); useMemo(() => 1, []); }
+    , 0);
+}
+
+test "is opt-in and supports rule configuration severity and disabling" {
+    try std.testing.expect(!(lint.Options{}).react_hooks_use_memo);
+    var options = lint.Options.allDisabled();
+    try std.testing.expect(options.setByCliName("react-hooks/use-memo", true));
+    try std.testing.expect(options.react_hooks_use_memo);
+    var config = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, "\"off\"", .{});
+    defer config.deinit();
+    try options.setByRuleConfigValue("react-hooks/use-memo", config.value);
+    try std.testing.expect(!options.react_hooks_use_memo);
+}
+
+fn check(source: []const u8, count: usize) !void {
+    var options = lint.Options.allDisabled();
+    options.react_hooks_use_memo = true;
+    var result = try lint.lintSource(std.testing.allocator, source, "fixture.tsx", options);
+    defer result.deinit(std.testing.allocator);
+    try std.testing.expectEqual(@as(usize, 0), helpers.countRule(result, "parse"));
+    try std.testing.expectEqual(count, helpers.countRule(result, "react-hooks/use-memo"));
+    for (result.diagnostics) |diagnostic| {
+        try std.testing.expectEqual(.@"error", diagnostic.severity);
+        try std.testing.expectEqual(@as(usize, 0), diagnostic.fixes.len);
+    }
+}
+
+test "resolves stable named callbacks and CommonJS hook aliases" {
+    try check(
+        \\const React = require('react'); const {useMemo: memoize} = React; const memo = memoize;
+        \\const calculate = async value => value; const alias = calculate;
+        \\function Component() { return memo(alias, []); }
+        \\function Other() { function* calc() { yield 1; } return React.useMemo(calc, []); }
+    , 3);
+}
+
+test "checks captured writes in named memo callbacks once" {
+    try check(
+        \\function Component() { let n = 0; const calc = () => { n++; return n; }; return [useMemo(calc, []), useMemo(calc, [])]; }
+    , 1);
+}
+
+test "does not resolve reassigned cyclic foreign or deferred callbacks" {
+    try check(
+        \\const {useMemo: foreign} = require('other');
+        \\function Component(require) { const {useMemo: local} = require('react'); return [local(async x => x, []), foreign(async x => x, [])]; }
+        \\function Other() { let calc = async x => x; calc = () => 1; const a = b; const b = a; return [useMemo(calc, []), useMemo(a, [])]; }
+        \\function Third() { const calc = async x => x; return () => useMemo(calc, []); }
+    , 0);
+}
+
+test "ignores dynamic module names and destructuring defaults" {
+    try check(
+        \\const react = 'other'; const {useMemo: memo} = require(react); function Component() { const {useMemo: other = memo} = unknown; return [memo(async x => x, []), other(async x => x, [])]; }
+    , 0);
+}
+
+test "terminates recursive memo invocation graphs without render owners" {
+    try check(
+        \\const calc = value => { useMemo(calc, []); return useMemo(calc, []); };
+    , 0);
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/UPSTREAM.md
+++ b/tests/snapshots/specs/react-hooks/use-memo/UPSTREAM.md
@@ -1,0 +1,35 @@
+# Upstream coverage: use-memo
+
+Reference: React `e92bda78750136493cb324e98df1726f62ba8e92`. These fixtures exercise the compiler validation passes
+exposed by `packages/eslint-plugin-react-hooks/src/shared/ReactCompiler.ts`.
+
+- [error.invalid-useMemo-callback-args.js](https://github.com/facebook/react/blob/e92bda78750136493cb324e98df1726f62ba8e92/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-useMemo-callback-args.js): 1 native diagnostics.
+- [error.invalid-useMemo-async-callback.js](https://github.com/facebook/react/blob/e92bda78750136493cb324e98df1726f62ba8e92/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.invalid-useMemo-async-callback.js): 1 native diagnostics.
+- [error.useMemo-callback-generator.js](https://github.com/facebook/react/blob/e92bda78750136493cb324e98df1726f62ba8e92/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/error.useMemo-callback-generator.js): 1 native diagnostics.
+
+Lowercase fixture entry points are capitalized because the upstream harness explicitly
+selects the function to compile, while the linter uses React naming conventions.
+
+## License for copied fixtures
+
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/snapshots/specs/react-hooks/use-memo/indirect.js
+++ b/tests/snapshots/specs/react-hooks/use-memo/indirect.js
@@ -1,0 +1,5 @@
+const {useMemo: memo} = require('react');
+const calculate = async value => value;
+function Component() {
+  return memo(calculate, []);
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/indirect.js.snap
+++ b/tests/snapshots/specs/react-hooks/use-memo/indirect.js.snap
@@ -1,0 +1,45 @@
+---
+fixture: "tests/snapshots/specs/react-hooks/use-memo/indirect.js"
+rule: "react-hooks/use-memo"
+---
+
+# Input
+
+```js
+const {useMemo: memo} = require('react');
+const calculate = async value => value;
+function Component() {
+  return memo(calculate, []);
+}
+```
+
+# Diagnostics
+
+count: 2
+
+## Diagnostic 1
+
+- rule: "react-hooks/use-memo"
+- severity: "error"
+- message: "useMemo callbacks must not accept parameters; capture the values needed for the calculation instead."
+- byte span: 66..71
+- start: 2:25
+- end: 2:30
+- source: "value"
+- fixes: 0
+
+## Diagnostic 2
+
+- rule: "react-hooks/use-memo"
+- severity: "error"
+- message: "useMemo callbacks must be synchronous and must not be async or generator functions."
+- byte span: 60..80
+- start: 2:19
+- end: 2:39
+- source: "async value => value"
+- fixes: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/react-hooks/use-memo/indirect.options.json
+++ b/tests/snapshots/specs/react-hooks/use-memo/indirect.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 2,
+  "fixes": "forbidden"
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/invalid.jsx
+++ b/tests/snapshots/specs/react-hooks/use-memo/invalid.jsx
@@ -1,0 +1,3 @@
+function Component() {
+  return useMemo(async (value) => value, []);
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/invalid.jsx.snap
+++ b/tests/snapshots/specs/react-hooks/use-memo/invalid.jsx.snap
@@ -1,0 +1,43 @@
+---
+fixture: "tests/snapshots/specs/react-hooks/use-memo/invalid.jsx"
+rule: "react-hooks/use-memo"
+---
+
+# Input
+
+```jsx
+function Component() {
+  return useMemo(async (value) => value, []);
+}
+```
+
+# Diagnostics
+
+count: 2
+
+## Diagnostic 1
+
+- rule: "react-hooks/use-memo"
+- severity: "error"
+- message: "useMemo callbacks must not accept parameters; capture the values needed for the calculation instead."
+- byte span: 46..53
+- start: 2:24
+- end: 2:31
+- source: "(value)"
+- fixes: 0
+
+## Diagnostic 2
+
+- rule: "react-hooks/use-memo"
+- severity: "error"
+- message: "useMemo callbacks must be synchronous and must not be async or generator functions."
+- byte span: 40..62
+- start: 2:18
+- end: 2:40
+- source: "async (value) => value"
+- fixes: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/react-hooks/use-memo/invalid.options.json
+++ b/tests/snapshots/specs/react-hooks/use-memo/invalid.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 2,
+  "fixes": "forbidden"
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-async-callback.js
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-async-callback.js
@@ -1,0 +1,6 @@
+function Component(a, b) {
+  let x = useMemo(async () => {
+    await a;
+  }, []);
+  return x;
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-async-callback.js.snap
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-async-callback.js.snap
@@ -1,0 +1,35 @@
+---
+fixture: "tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-async-callback.js"
+rule: "react-hooks/use-memo"
+---
+
+# Input
+
+```js
+function Component(a, b) {
+  let x = useMemo(async () => {
+    await a;
+  }, []);
+  return x;
+}
+```
+
+# Diagnostics
+
+count: 1
+
+## Diagnostic 1
+
+- rule: "react-hooks/use-memo"
+- severity: "error"
+- message: "useMemo callbacks must be synchronous and must not be async or generator functions."
+- byte span: 45..75
+- start: 2:19
+- end: 4:4
+- source: "async () => {\n    await a;\n  }"
+- fixes: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-async-callback.options.json
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-async-callback.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 1,
+  "fixes": "forbidden"
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-callback-args.js
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-callback-args.js
@@ -1,0 +1,4 @@
+function Component(a, b) {
+  let x = useMemo(c => a, []);
+  return x;
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-callback-args.js.snap
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-callback-args.js.snap
@@ -1,0 +1,33 @@
+---
+fixture: "tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-callback-args.js"
+rule: "react-hooks/use-memo"
+---
+
+# Input
+
+```js
+function Component(a, b) {
+  let x = useMemo(c => a, []);
+  return x;
+}
+```
+
+# Diagnostics
+
+count: 1
+
+## Diagnostic 1
+
+- rule: "react-hooks/use-memo"
+- severity: "error"
+- message: "useMemo callbacks must not accept parameters; capture the values needed for the calculation instead."
+- byte span: 45..46
+- start: 2:19
+- end: 2:20
+- source: "c"
+- fixes: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-callback-args.options.json
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.invalid-useMemo-callback-args.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 1,
+  "fixes": "forbidden"
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.useMemo-callback-generator.js
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.useMemo-callback-generator.js
@@ -1,0 +1,9 @@
+function Component(a, b) {
+  // we don't handle generators at all so this test isn't
+  // useful for now, but adding this test in case we do
+  // add support for generators in the future.
+  let x = useMemo(function* () {
+    yield a;
+  }, []);
+  return x;
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.useMemo-callback-generator.js.snap
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.useMemo-callback-generator.js.snap
@@ -1,0 +1,38 @@
+---
+fixture: "tests/snapshots/specs/react-hooks/use-memo/upstream-error.useMemo-callback-generator.js"
+rule: "react-hooks/use-memo"
+---
+
+# Input
+
+```js
+function Component(a, b) {
+  // we don't handle generators at all so this test isn't
+  // useful for now, but adding this test in case we do
+  // add support for generators in the future.
+  let x = useMemo(function* () {
+    yield a;
+  }, []);
+  return x;
+}
+```
+
+# Diagnostics
+
+count: 1
+
+## Diagnostic 1
+
+- rule: "react-hooks/use-memo"
+- severity: "error"
+- message: "useMemo callbacks must be synchronous and must not be async or generator functions."
+- byte span: 206..237
+- start: 5:19
+- end: 7:4
+- source: "function* () {\n    yield a;\n  }"
+- fixes: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/react-hooks/use-memo/upstream-error.useMemo-callback-generator.options.json
+++ b/tests/snapshots/specs/react-hooks/use-memo/upstream-error.useMemo-callback-generator.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "diagnostics",
+  "diagnostic_count": 1,
+  "fixes": "forbidden"
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/valid.jsx
+++ b/tests/snapshots/specs/react-hooks/use-memo/valid.jsx
@@ -1,0 +1,3 @@
+function Component() {
+  return useMemo(() => 42, []);
+}

--- a/tests/snapshots/specs/react-hooks/use-memo/valid.jsx.snap
+++ b/tests/snapshots/specs/react-hooks/use-memo/valid.jsx.snap
@@ -1,0 +1,21 @@
+---
+fixture: "tests/snapshots/specs/react-hooks/use-memo/valid.jsx"
+rule: "react-hooks/use-memo"
+---
+
+# Input
+
+```jsx
+function Component() {
+  return useMemo(() => 42, []);
+}
+```
+
+# Diagnostics
+
+count: 0
+
+# First fix pass
+
+- fixed: false
+- applied diagnostics: 0

--- a/tests/snapshots/specs/react-hooks/use-memo/valid.options.json
+++ b/tests/snapshots/specs/react-hooks/use-memo/valid.options.json
@@ -1,0 +1,5 @@
+{
+  "expect": "clean",
+  "diagnostic_count": 0,
+  "fixes": "forbidden"
+}

--- a/tests/wasm.mjs
+++ b/tests/wasm.mjs
@@ -456,3 +456,20 @@ test("supports empty and repeated calls across memory growth", () => {
     assert.equal(result.ok, true);
   }
 });
+
+test("React Compiler use-memo works in WebAssembly", () => {
+  const ruleId = "react-hooks/use-memo";
+  const source = "import {useMemo as calculate} from 'react'; function Component() { return calculate(async (value) => value, []); }";
+  const result = linter.lint(source, { filePath: "component.tsx", rules: { [ruleId]: "warn" } });
+  assert.equal(result.diagnostics.length, 2);
+  assert.ok(result.diagnostics.every((item) => item.ruleId === ruleId && item.severity === "warning" && item.fixes.length === 0));
+  const disabled = linter.lint(source, { filePath: "component.tsx" });
+  assert.ok(!disabled.diagnostics.some((item) => item.ruleId === ruleId));
+});
+
+test("React Compiler use-memo resolves CommonJS and indirect values in WebAssembly", () => {
+  const ruleId = "react-hooks/use-memo";
+  const result = linter.lint("const {useMemo: memo} = require('react'); const calc = async value => value; function Component() { return memo(calc, []); }", { filePath: "component.tsx", rules: { [ruleId]: "error" } });
+  assert.equal(result.diagnostics.length, 2);
+  assert.ok(result.diagnostics.every((item) => item.ruleId === ruleId));
+});


### PR DESCRIPTION
Add opt-in `react-hooks/use-memo` diagnostics for callbacks that accept parameters, are async/generators, or directly reassign captured bindings. Both inline callbacks and stable named callbacks are checked: `const calc = async value => value; useMemo(calc, [])` reports the invalid signature. Shared symbol-based resolution supports ES imports, literal CommonJS React imports, stable local aliases, and shadowing. Bounded alias resolution and visited invocation paths terminate cyclic references. Nested deferred closure writes remain outside this native check.

The rule remains disabled by default and outside the frontend preset. Native, npm configuration/migration/suppression, and WebAssembly entry points are covered. These checks implement a documented subset of React Compiler validation rather than running the compiler engine.

Upstream reference: [React `e92bda787501`](https://github.com/facebook/react/tree/e92bda78750136493cb324e98df1726f62ba8e92). Fixture provenance, adaptations, and MIT attribution are in `tests/snapshots/specs/react-hooks/use-memo/UPSTREAM.md`.

Validation on the complete four-rule stack:

- `zig build test -Doptimize=ReleaseFast -j1` (2213 unit tests and 38 diagnostic snapshots)
- `zig build test-wasm -Doptimize=ReleaseFast -j1` (34 tests)
- `zig build -Doptimize=ReleaseFast -j1`
- `UTOO_LINT_BIN=<freshly-built-binary> pnpm --dir npm/utoo-lint test` (205 npm tests and TypeScript checks)
- `zig fmt --check build.zig src tests` and `git diff --check`

Regression coverage includes stable and reassigned aliases, CommonJS/shadowed imports, indirect and deferred callbacks, cyclic references, and rule-specific diagnostic spans.
